### PR TITLE
Introduce `ObserverOptions` for signal to live in

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ const googTrades = streamStock('GOOG');
 const nflxTrades = streamStock('NFLX');
 
 const googController = new AbortController();
-const googSubscription = googTrades.subscribe({next: updateView, signal: googController.signal});
+const googSubscription = googTrades.subscribe({next: updateView}, {signal: googController.signal});
 const nflxSubscription = nflxTrades.subscribe({next: updateView, ...});
 
 // And the stream can disconnect later, which
@@ -313,9 +313,11 @@ dictionary Observer {
   ObserverCallback next;
   VoidFunction complete;
   ObserverCallback error;
-
-  AbortSignal signal;
 };
+
+dictionary ObserverOptions {
+  AbortSignal signal;
+}
 
 dictionary PromiseOptions {
   AbortSignal signal;
@@ -346,7 +348,7 @@ callback Visitor = undefined (any element, unsigned long long index)
 [Exposed=*]
 interface Observable {
   constructor(SubscribeCallback callback);
-  undefined subscribe(optional Observer observer = {});
+  undefined subscribe(optional Observer observer = {}, optional ObserverOptions = {});
 
   undefined finally(VoidFunction callback);
 
@@ -474,8 +476,7 @@ let controller = new AbortController();
 observable.subscribe({
 	next: (data) => {
 		if (data > 100) controller.abort();
-	},
-	signal: controller.signal,
+	}}, {signal: controller.signal},
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ dictionary Observer {
   ObserverCallback error;
 };
 
-dictionary ObserverOptions {
+dictionary SubscribeOptions {
   AbortSignal signal;
 }
 
@@ -348,7 +348,7 @@ callback Visitor = undefined (any element, unsigned long long index)
 [Exposed=*]
 interface Observable {
   constructor(SubscribeCallback callback);
-  undefined subscribe(optional Observer observer = {}, optional ObserverOptions = {});
+  undefined subscribe(optional Observer observer = {}, optional SubscribeOptions = {});
 
   undefined finally(VoidFunction callback);
 


### PR DESCRIPTION
This closes #84.