### PR TITLE
Support Observer callback union for subscription

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -167,6 +167,8 @@ dictionary Observer {
   VoidFunction complete;
 };
 
+typedef (ObserverCallback or Observer) ObserverUnion;
+
 dictionary SubscribeOptions {
   AbortSignal signal;
 };
@@ -185,7 +187,7 @@ callback Visitor = undefined (any element, unsigned long long index);
 [Exposed=*]
 interface Observable {
   constructor(SubscribeCallback callback);
-  undefined subscribe(optional Observer observer = {}, optional SubscribeOptions options = {});
+  undefined subscribe(optional ObserverUnion observer = {}, optional SubscribeOptions options = {});
 
   undefined finally(VoidFunction callback);
 


### PR DESCRIPTION
This closes #71. The WebIDL Standard is now poised to support typedef unions between dictionary and callback types, which would enables a highly desired ergonomic feature: subscribing with just a callback instead of a full-blown `Observer` dictionary. See https://github.com/whatwg/webidl/pull/1353 and https://github.com/WICG/observable/issues/71#issuecomment-1804042861. The work is just waiting on another implementer besides Chromium, which we may be able to get via this proposal, which is a concrete user of this proposed Web IDL behavior.

Work is underway to update the Chromium implementation to match this as well: https://chromium-review.googlesource.com/c/chromium/src/+/5071992


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/89.html" title="Last updated on Nov 29, 2023, 4:04 PM UTC (116ad8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/89/e153f01...116ad8a.html" title="Last updated on Nov 29, 2023, 4:04 PM UTC (116ad8a)">Diff</a>