### PR TITLE
Null check algorithms that get null after closing

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -199,7 +199,8 @@ The <dfn attribute for=Subscriber><code>signal</code></dfn> getter steps are to 
     1. If [=this=]'s [=relevant global object=] is a {{Window}} object, and its [=associated
        Document=] is not [=Document/fully active=], then return.
 
-    1. Run [=this=]'s [=Subscriber/next algorithm=] algorithm given |value|.
+    1. If [=this=]'s [=Subscriber/next algorithm=] is not null, then run [=this=]'s
+       [=Subscriber/next algorithm=] given |value|.
 
        [=Assert=]: No <a spec=webidl lt="an exception was thrown">exception was thrown</a>.
 </div>
@@ -214,9 +215,11 @@ The <dfn attribute for=Subscriber><code>signal</code></dfn> getter steps are to 
 
     1. [=close a subscription|Close=] [=this=].
 
-    1. Run |error algorithm| given |error|.
+    1. If |error algorithm| is not null, then run |error algorithm| given |error|.
 
        [=Assert=]: No <a spec=webidl lt="an exception was thrown">exception was thrown</a>.
+
+    1. Otherwise (i.e., when |error algorithm| is null), [=report the exception=] |error|.
 
     1. [=AbortController/Signal abort=] [=this=]'s [=Subscriber/complete or error controller=].
 </div>
@@ -231,7 +234,7 @@ The <dfn attribute for=Subscriber><code>signal</code></dfn> getter steps are to 
 
     1. [=close a subscription|Close=] [=this=].
 
-    1. Run |complete algorithm|.
+    1. If |complete algorithm| is not null, then run |complete algorithm|.
 
        [=Assert=]: No <a spec=webidl lt="an exception was thrown">exception was thrown</a>.
 


### PR DESCRIPTION
The web platform tests currently assert that the behavior of this PR is implemented correctly, however I missed this as part of the abstraction work in https://github.com/WICG/observable/pull/95.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/98.html" title="Last updated on Jan 9, 2024, 1:46 AM UTC (16728bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/98/75d46a9...16728bd.html" title="Last updated on Jan 9, 2024, 1:46 AM UTC (16728bd)">Diff</a>