### PR TITLE
Spec the `map()` operator

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -664,6 +664,8 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
     1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
+       1. Let |controller| be a [=new=] {{AbortController}}.
+
        1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
 
           : [=internal observer/next steps=]
@@ -671,8 +673,8 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
                 |mappedValue| be the returned value.
 
                 If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>,
-                then run |subscriber|'s {{Subscriber/error()}} method, given |E|, and abort these
-                steps.
+                then run |subscriber|'s {{Subscriber/error()}} method, given |E|,
+                [=AbortController/signal abort=] |controller|, and abort these steps.
 
              1. Run |subscriber|'s {{Subscriber/next()}} method, given |mappedValue|.
 
@@ -683,8 +685,11 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
           : [=internal observer/complete steps=]
           :: Run |subscriber|'s {{Subscriber/complete()}} method.
 
-       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is
-          |subscriber|'s [=AbortController/signal=].
+       1. Let |signal| be the result of [=creating a dependent abort signal=] from the list
+          «|controller|'s [=AbortController/signal=], |subscriber|'s [=Subscriber/signal=]», using
+          {{AbortSignal}}, and the [=current realm=].
+
+       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is |signal|.
 
        1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
           given |sourceObserver| and |options|.

--- a/spec.bs
+++ b/spec.bs
@@ -659,7 +659,40 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 <div algorithm>
   The <dfn for=Observable method><code>map(|mapper|)</code></dfn> method steps are:
 
-    1. <span class=XXX>TODO: Spec this and use |mapper|.</span>
+    1. Let |sourceObservable| be [=this=].
+
+    1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+       algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+
+       1. Let |controller| be a [=new=] {{AbortController}}.
+
+       1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
+
+          : [=internal observer/next steps=]
+          :: 1. [=Invoke=] |mapper| with the passed in <var ignore>value</var>, and let
+                |mappedValue| be the returned value.
+
+                If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>,
+                then [=report the exception=] |E| and abort these steps.
+
+             1. Run |subscriber|'s {{Subscriber/next()}} method, given |mappedValue|.
+
+          : [=internal observer/error steps=]
+          :: 1. Run |subscriber|'s {{Subscriber/error()}} method, given the passed in <var
+                ignore>error</var>.
+
+             1. [=AbortController/Signal abort=] |controller|.
+
+          : [=internal observer/complete steps=]
+          :: Run |subscriber|'s {{Subscriber/complete()}} method.
+
+       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is
+          |controller|'s [=AbortController/signal=].
+
+       1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
+          given |sourceObserver| and |options|.
+
+    1. Return |observable|.
 </div>
 
 <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -664,8 +664,6 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
     1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
-       1. Let |controller| be a [=new=] {{AbortController}}.
-
        1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
 
           : [=internal observer/next steps=]
@@ -673,21 +671,20 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
                 |mappedValue| be the returned value.
 
                 If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>,
-                then [=report the exception=] |E| and abort these steps.
+                then run |subscriber|'s {{Subscriber/error()}} method, given |E|, and abort these
+                steps.
 
              1. Run |subscriber|'s {{Subscriber/next()}} method, given |mappedValue|.
 
           : [=internal observer/error steps=]
-          :: 1. Run |subscriber|'s {{Subscriber/error()}} method, given the passed in <var
-                ignore>error</var>.
-
-             1. [=AbortController/Signal abort=] |controller|.
+          :: Run |subscriber|'s {{Subscriber/error()}} method, given the passed in <var
+             ignore>error</var>.
 
           : [=internal observer/complete steps=]
           :: Run |subscriber|'s {{Subscriber/complete()}} method.
 
        1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is
-          |controller|'s [=AbortController/signal=].
+          |subscriber|'s [=AbortController/signal=].
 
        1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
           given |sourceObserver| and |options|.

--- a/spec.bs
+++ b/spec.bs
@@ -666,15 +666,19 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
        1. Let |controller| be a [=new=] {{AbortController}}.
 
+       1. Let |idx| be an {{unsigned long long}}, initially 0.
+
        1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
 
           : [=internal observer/next steps=]
-          :: 1. [=Invoke=] |mapper| with the passed in <var ignore>value</var>, and let
+          :: 1. [=Invoke=] |mapper| with the passed in <var ignore>value</var>, and |idx|, and let
                 |mappedValue| be the returned value.
 
                 If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>,
                 then run |subscriber|'s {{Subscriber/error()}} method, given |E|,
                 [=AbortController/signal abort=] |controller|, and abort these steps.
+
+             1. Increment |idx|.
 
              1. Run |subscriber|'s {{Subscriber/next()}} method, given |mappedValue|.
 


### PR DESCRIPTION
The original version of this PR made it so if the `|mapper|` callback throws an error, it is "reported" to the global.

However, I've since fixed this to invoke the `error()` method on the relevant "Subscriber". This will either (a) [let the subscriber handle it][1], or (b) if there are no error steps, report the exception (due to the [default error steps][2]). That's the right behavior.

Additionally, in this error-case we *also* need to unsubscribe from the `|sourceObservable|`, which is accomplished by having the nexts steps abort an `AbortController` that `|signal|` is derived from, where `|signal|` is the `AbortSignal` passed into the outer Observable subscription.

Tests are in https://github.com/web-platform-tests/wpt/pull/42996/files#diff-8bcbcee0a9e290fe595f3a4d260648dc3900c67bab5925715011728b1df24d7f (written by @benlesh) but I will port them over to the Chromium CL, add more over there, and land them with the implementation. They'll get upstreamed to the external WPT repository with appropriate [Git commit attribution][3].

[1]: https://wicg.github.io/observable/#dom-subscriptionobserver-error
[2]: https://wicg.github.io/observable/#ref-for-default-error-algorithm
[3]: https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors#creating-co-authored-commits-on-the-command-line


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/110.html" title="Last updated on Feb 8, 2024, 9:45 PM UTC (cb80f57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/110/35b0376...cb80f57.html" title="Last updated on Feb 8, 2024, 9:45 PM UTC (cb80f57)">Diff</a>