### PR TITLE
Spec the `take()` operator

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -718,8 +718,6 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        1. If |amount| is 0, then run |subscriber|'s {{Subscriber/complete()}} method and abort
           these steps.
 
-       1. Let |controller| be a [=new=] {{AbortController}}.
-
        1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
 
           : [=internal observer/next steps=]
@@ -728,11 +726,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
              1. Decrement |amount|.
 
-             1. If |amount| is 0, then:
-
-                1. Run |subscriber|'s {{Subscriber/complete()}} method.
-
-                1. [=AbortController/Signal abort=] |controller|.
+             1. If |amount| is 0, then run |subscriber|'s {{Subscriber/complete()}} method.
 
           : [=internal observer/error steps=]
           :: Run |subscriber|'s {{Subscriber/error()}} method, given the passed in <var
@@ -741,11 +735,8 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
           : [=internal observer/complete steps=]
           :: Run |subscriber|'s {{Subscriber/complete()}} method.
 
-       1. Let |signal| be the result of [=creating a dependent abort signal=] from the list
-          «|controller|'s [=AbortController/signal=], |subscriber|'s [=Subscriber/signal=]», using
-          {{AbortSignal}}, and the [=current realm=].
-
-       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is |signal|.
+       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is
+          |subscriber|'s [=Subscriber/signal=].
 
        1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
           given |sourceObserver| and |options|.

--- a/spec.bs
+++ b/spec.bs
@@ -710,7 +710,47 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 <div algorithm>
   The <dfn for=Observable method><code>take(|amount|)</code></dfn> method steps are:
 
-    1. <span class=XXX>TODO: Spec this and use |amount|.</span>
+    1. Let |sourceObservable| be [=this=].
+
+    1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+       algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+
+       1. If |amount| is 0, then run |subscriber|'s {{Subscriber/complete()}} method and abort
+          these steps.
+
+       1. Let |controller| be a [=new=] {{AbortController}}.
+
+       1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
+
+          : [=internal observer/next steps=]
+          :: 1. Run |subscriber|'s {{Subscriber/next()}} method with the passed in <var
+                ignore>value</var>.
+
+             1. Decrement |amount|.
+
+             1. If |amount| is 0, then:
+
+                1. Run |subscriber|'s {{Subscriber/complete()}} method.
+
+                1. [=AbortController/Signal abort=] |controller|.
+
+          : [=internal observer/error steps=]
+          :: Run |subscriber|'s {{Subscriber/error()}} method, given the passed in <var
+             ignore>error</var>.
+
+          : [=internal observer/complete steps=]
+          :: Run |subscriber|'s {{Subscriber/complete()}} method.
+
+       1. Let |signal| be the result of [=creating a dependent abort signal=] from the list
+          «|controller|'s [=AbortController/signal=], |subscriber|'s [=Subscriber/signal=]», using
+          {{AbortSignal}}, and the [=current realm=].
+
+       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is |signal|.
+
+       1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
+          given |sourceObserver| and |options|.
+
+    1. Return |observable|.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This operator's semantics include the behavior of not ever subscribing to the source Observable if the passed in `amount` argument is `0`. Additionally, in that case we automatically invoke `Subscriber#complete()`.

At the moment, the tests for this are in https://github.com/web-platform-tests/wpt/pull/44512, but they will be moved to https://github.com/web-platform-tests/wpt/pull/42996, and then moved to the Chromium implementation where they'll land as part of the Chromium review process.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/113.html" title="Last updated on Feb 13, 2024, 7:38 PM UTC (5f16fc8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/113/29fabd5...5f16fc8.html" title="Last updated on Feb 13, 2024, 7:38 PM UTC (5f16fc8)">Diff</a>