### PR TITLE
Simplify `map()` internal observer

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -657,8 +657,6 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
     1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
-       1. Let |controller| be a [=new=] {{AbortController}}.
-
        1. Let |idx| be an {{unsigned long long}}, initially 0.
 
        1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
@@ -668,8 +666,8 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
                 |mappedValue| be the returned value.
 
                 If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>,
-                then run |subscriber|'s {{Subscriber/error()}} method, given |E|,
-                [=AbortController/signal abort=] |controller|, and abort these steps.
+                then run |subscriber|'s {{Subscriber/error()}} method, given |E|, and abort these
+                steps.
 
              1. Increment |idx|.
 
@@ -682,11 +680,8 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
           : [=internal observer/complete steps=]
           :: Run |subscriber|'s {{Subscriber/complete()}} method.
 
-       1. Let |signal| be the result of [=creating a dependent abort signal=] from the list
-          «|controller|'s [=AbortController/signal=], |subscriber|'s [=Subscriber/signal=]», using
-          {{AbortSignal}}, and the [=current realm=].
-
-       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is |signal|.
+       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is
+          |subscriber|'s [=Subscriber/signal=].
 
        1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
           given |sourceObserver| and |options|.


### PR DESCRIPTION
When spec'ing the `map()` operator, I was originally under the impression that if the `Mapper` callback threw an error, we would have to signal abort on an `AbortController` that manipulated the source Observable's subscriber. But upon reading the spec, I realize that simply:

> If [an exception E was thrown](https://webidl.spec.whatwg.org/#an-exception-was-thrown), then run subscriber’s [error()](https://wicg.github.io/observable/#dom-subscriber-error) method

... is plenty. That's because when we signal error on the "outer" `Subscriber`, this will abort the `AbortSignal` associated with that "outer" subscriber's AbortSignal.... and that "outer" AbortSignal is what the source Observable's subscription's signal is derived from.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/116.html" title="Last updated on Feb 21, 2024, 7:12 PM UTC (8d20b49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/116/0a417ad...8d20b49.html" title="Last updated on Feb 21, 2024, 7:12 PM UTC (8d20b49)">Diff</a>