### PR TITLE
Spec the `drop()` operator

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -716,7 +716,35 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 <div algorithm>
   The <dfn for=Observable method><code>drop(|amount|)</code></dfn> method steps are:
 
-    1. <span class=XXX>TODO: Spec this and use |amount|.</span>
+    1. Let |sourceObservable| be [=this=].
+
+    1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+       algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+
+       1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
+
+          : [=internal observer/next steps=]
+          :: 1. If |amount| is &gt; 0, then decrement |amount| and abort these steps.
+
+             1. [=Assert=]: |amount| is 0.
+
+             1. Run |subscriber|'s {{Subscriber/next()}} method with the passed in <var
+                ignore>value</var>.
+
+          : [=internal observer/error steps=]
+          :: Run |subscriber|'s {{Subscriber/error()}} method, given the passed in <var
+             ignore>error</var>.
+
+          : [=internal observer/complete steps=]
+          :: Run |subscriber|'s {{Subscriber/complete()}} method.
+
+       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is
+          |subscriber|'s [=Subscriber/signal=].
+
+       1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
+          given |sourceObserver| and |options|.
+
+    1. Return |observable|.
 </div>
 
 <div algorithm>


### PR DESCRIPTION
CC @keithamus, if you're interested.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/117.html" title="Last updated on Feb 14, 2024, 1:50 AM UTC (ac3fd48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/117/29fabd5...ac3fd48.html" title="Last updated on Feb 14, 2024, 1:50 AM UTC (ac3fd48)">Diff</a>