### PR TITLE
Fix Observable unsubscription timing

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -216,13 +216,13 @@ The <dfn attribute for=Subscriber><code>signal</code></dfn> getter steps are to 
 
     1. [=close a subscription|Close=] [=this=].
 
+    1. [=AbortController/Signal abort=] [=this=]'s [=Subscriber/complete or error controller=].
+
     1. If |error algorithm| is not null, then run |error algorithm| given |error|.
 
        [=Assert=]: No <a spec=webidl lt="an exception was thrown">exception was thrown</a>.
 
     1. Otherwise (i.e., when |error algorithm| is null), [=report the exception=] |error|.
-
-    1. [=AbortController/Signal abort=] [=this=]'s [=Subscriber/complete or error controller=].
 </div>
 
 <div algorithm>
@@ -235,11 +235,11 @@ The <dfn attribute for=Subscriber><code>signal</code></dfn> getter steps are to 
 
     1. [=close a subscription|Close=] [=this=].
 
+    1. [=AbortController/Signal abort=] [=this=]'s [=Subscriber/complete or error controller=].
+
     1. If |complete algorithm| is not null, then run |complete algorithm|.
 
        [=Assert=]: No <a spec=webidl lt="an exception was thrown">exception was thrown</a>.
-
-    1. [=AbortController/Signal abort=] [=this=]'s [=Subscriber/complete or error controller=].
 </div>
 
 <div algorithm>


### PR DESCRIPTION
This PR "fixes" Observable unsubscription/teardown timing. As a matter
of accidental historical precedent, Observables in JavaScript (but not
in other languages) had implemented the "rule" that upon
Subscriber#error() or Subscriber#complete(), the subscriber would:
 1. First, invoke the appropriate Observer callback, if provided (i.e.,
    complete() or error() callback).
 2. Signal abort Subscriber#signal, which invokes any teardowns and also
    fires the `abort` event at the signal.

However, after dom@chromium.org discussed this more with
ben@benlesh.com, we came to the conclusion that the principle of "as
soon as you know you will teardown, you MUST close the subscription and
any upstream subscriptions" should be followed. This means the above
steps must be inverted. This is a small-in-size but medium-in-impact
design change for the Observable concept, and led to [a blog post][1] and
[an announcement][2] that the RxJS library intends to change its
historical ordering of these events.

This PR is made alongside https://crrev.com/c/5311097 and https://github.com/web-platform-tests/wpt/pull/44682, which fixes the Chromium implementation and test expectations respectively.

[1]: https://benlesh.com/posts/observables-are-broken-and-so-is-javascript/
[2]: https://github.com/ReactiveX/rxjs/issues/7443


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/120.html" title="Last updated on Feb 20, 2024, 10:05 PM UTC (5c80771)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/120/29fabd5...5c80771.html" title="Last updated on Feb 20, 2024, 10:05 PM UTC (5c80771)">Diff</a>