### PR TITLE
Spec `some()`, `every()`, and `find()` operators

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1116,19 +1116,148 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 <div algorithm>
   The <dfn for=Observable method><code>every(|predicate|, |options|)</code></dfn> method steps are:
 
-    1. <span class=XXX>TODO: Spec this and use |predicate| and |options|.</span>
+    1. Let |p| [=a new promise=].
+
+    1. Let |controller| be a [=new=] {{AbortController}}.
+
+    1. Let |internal options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is the
+       result of [=creating a dependent abort signal=] from the list
+       «|controller|'s [=AbortController/signal=], |options|'s
+       {{SubscribeOptions/signal}} if non-null», using {{AbortSignal}}, and the [=current realm=].
+
+    1. If |internal options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s
+          [=AbortSignal/abort reason=].
+
+       1. Return |p|.
+
+    1. [=AbortSignal/add|Add the following abort algorithm=] to |internal options|'s
+       {{SubscribeOptions/signal}}:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
+          reason=].
+
+    1. Let |observer| be a new [=internal observer=], initialized as follows:
+
+       : [=internal observer/next steps=]
+       :: 1. [=Invoke=] |predicate| with the passed in <var ignore>value</var>, and let |passed| be
+             the returned value.
+
+             If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
+             [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
+
+         1. If |passed| is false, then [=resolve=] |p| with false, and [=AbortController/signal
+            abort=] |controller|.
+
+       : [=internal observer/error steps=]
+       :: [=Reject=] |p| with the passed in <var ignore>error</var>.
+
+       : [=internal observer/complete steps=]
+       :: [=Resolve=] |p| with true.
+
+    1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
+       and |internal options|.
+
+    1. Return |p|.
 </div>
 
 <div algorithm>
   The <dfn for=Observable method><code>find(|predicate|, |options|)</code></dfn> method steps are:
 
-    1. <span class=XXX>TODO: Spec this and use |predicate| and |options|.</span>
+    1. Let |p| [=a new promise=].
+
+    1. Let |controller| be a [=new=] {{AbortController}}.
+
+    1. Let |internal options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is the
+       result of [=creating a dependent abort signal=] from the list
+       «|controller|'s [=AbortController/signal=], |options|'s
+       {{SubscribeOptions/signal}} if non-null», using {{AbortSignal}}, and the [=current realm=].
+
+    1. If |internal options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s
+          [=AbortSignal/abort reason=].
+
+       1. Return |p|.
+
+    1. [=AbortSignal/add|Add the following abort algorithm=] to |internal options|'s
+       {{SubscribeOptions/signal}}:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
+          reason=].
+
+    1. Let |observer| be a new [=internal observer=], initialized as follows:
+
+       : [=internal observer/next steps=]
+       :: 1. [=Invoke=] |predicate| with the passed in |value|, and let |passed| be the returned
+             value.
+
+             If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
+             [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
+
+         1. If |passed| is true, then [=resolve=] |p| with |value|, and [=AbortController/signal
+            abort=] |controller|.
+
+       : [=internal observer/error steps=]
+       :: [=Reject=] |p| with the passed in <var ignore>error</var>.
+
+       : [=internal observer/complete steps=]
+       :: [=Resolve=] |p| with false.
+
+    1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
+       and |internal options|.
+
+    1. Return |p|.
 </div>
 
 <div algorithm>
   The <dfn for=Observable method><code>some(|predicate|, |options|)</code></dfn> method steps are:
 
-    1. <span class=XXX>TODO: Spec this and use |predicate| and |options|.</span>
+    1. Let |p| [=a new promise=].
+
+    1. Let |controller| be a [=new=] {{AbortController}}.
+
+    1. Let |internal options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is the
+       result of [=creating a dependent abort signal=] from the list
+       «|controller|'s [=AbortController/signal=], |options|'s
+       {{SubscribeOptions/signal}} if non-null», using {{AbortSignal}}, and the [=current realm=].
+
+    1. If |internal options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s
+          [=AbortSignal/abort reason=].
+
+       1. Return |p|.
+
+    1. [=AbortSignal/add|Add the following abort algorithm=] to |internal options|'s
+       {{SubscribeOptions/signal}}:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
+          reason=].
+
+    1. Let |observer| be a new [=internal observer=], initialized as follows:
+
+       : [=internal observer/next steps=]
+       :: 1. [=Invoke=] |predicate| with the passed in <var ignore>value</var>, and let |passed| be
+             the returned value.
+
+             If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
+             [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
+
+         1. If |passed| is true, then [=resolve=] |p| with true, and [=AbortController/signal
+            abort=] |controller|.
+
+       : [=internal observer/error steps=]
+       :: [=Reject=] |p| with the passed in <var ignore>error</var>.
+
+       : [=internal observer/complete steps=]
+       :: [=Resolve=] |p| with false.
+
+    1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
+       and |internal options|.
+
+    1. Return |p|.
 </div>
 
 <div algorithm>

--- a/spec.bs
+++ b/spec.bs
@@ -1138,14 +1138,18 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
           reason=].
 
+    1. Let |idx| be an {{unsigned long long}}, initially 0.
+
     1. Let |observer| be a new [=internal observer=], initialized as follows:
 
        : [=internal observer/next steps=]
-       :: 1. [=Invoke=] |predicate| with the passed in <var ignore>value</var>, and let |passed| be
-             the returned value.
+       :: 1. [=Invoke=] |predicate| with the passed in <var ignore>value</var> and |idx|, and let
+             |passed| be the returned value.
 
              If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
              [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
+
+         1. Set |idx| to |idx| + 1.
 
          1. If |passed| is false, then [=resolve=] |p| with false, and [=AbortController/signal
             abort=] |controller|.
@@ -1187,14 +1191,18 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
           reason=].
 
+    1. Let |idx| be an {{unsigned long long}}, initially 0.
+
     1. Let |observer| be a new [=internal observer=], initialized as follows:
 
        : [=internal observer/next steps=]
-       :: 1. [=Invoke=] |predicate| with the passed in |value|, and let |passed| be the returned
-             value.
+       :: 1. [=Invoke=] |predicate| with the passed in |value| an |idx|, and let |passed| be the
+             returned value.
 
              If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
              [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
+
+         1. Set |idx| to |idx| + 1.
 
          1. If |passed| is true, then [=resolve=] |p| with |value|, and [=AbortController/signal
             abort=] |controller|.
@@ -1236,14 +1244,18 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
           reason=].
 
+    1. Let |idx| be an {{unsigned long long}}, initially 0.
+
     1. Let |observer| be a new [=internal observer=], initialized as follows:
 
        : [=internal observer/next steps=]
-       :: 1. [=Invoke=] |predicate| with the passed in <var ignore>value</var>, and let |passed| be
-             the returned value.
+       :: 1. [=Invoke=] |predicate| with the passed in <var ignore>value</var> and |idx|, and let
+             |passed| be the returned value.
 
              If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
              [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
+
+         1. Set |idx| to |idx| + 1.
 
          1. If |passed| is true, then [=resolve=] |p| with true, and [=AbortController/signal
             abort=] |controller|.

--- a/spec.bs
+++ b/spec.bs
@@ -1203,7 +1203,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        :: [=Reject=] |p| with the passed in <var ignore>error</var>.
 
        : [=internal observer/complete steps=]
-       :: [=Resolve=] |p| with false.
+       :: [=Resolve=] |p| with {{undefined}}.
 
     1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
        and |internal options|.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/137.html" title="Last updated on Apr 23, 2024, 7:23 PM UTC (d609f27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/137/b4b9d43...d609f27.html" title="Last updated on Apr 23, 2024, 7:23 PM UTC (d609f27)">Diff</a>