### PR TITLE
Revert "Spec the `last()` operator"

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -374,7 +374,6 @@ interface Observable {
   Promise<undefined> forEach(Visitor callback, optional SubscribeOptions options = {});
   Promise<boolean> every(Predicate predicate, optional SubscribeOptions options = {});
   // Maybe? Promise<any> first(optional SubscribeOptions options = {});
-  Promise<any> last(optional SubscribeOptions options = {});
   Promise<any> find(Predicate predicate, optional SubscribeOptions options = {});
   Promise<boolean> some(Predicate predicate, optional SubscribeOptions options = {});
   Promise<any> reduce(Reducer reducer, optional any initialValue, optional SubscribeOptions options = {});
@@ -1286,51 +1285,6 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
     1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
        and |internal options|.
-
-    1. Return |p|.
-</div>
-
-<div algorithm>
-  The <dfn for=Observable method><code>last(|options|)</code></dfn> method steps are:
-
-    1. Let |p| [=a new promise=].
-
-    1. If |options|'s {{SubscribeOptions/signal}} is not null:
-
-       1. If |options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then:
-
-          1. [=Reject=] |p| with |options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
-             reason=].
-
-          1. Return |p|.
-
-       1. [=AbortSignal/add|Add the following abort algorithm=] to |options|'s
-          {{SubscribeOptions/signal}}:
-
-          1. [=Reject=] |p| with |options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
-             reason=].
-
-    1. Let |lastValue| be an {{any}}-or-null, initially null.
-
-    1. Let |hasLastValue| be a [=boolean=], initially false.
-
-    1. Let |observer| be a new [=internal observer=], initialized as follows:
-
-       : [=internal observer/next steps=]
-       :: 1. Set |hasLastValue| to true.
-       
-          1. Set |lastValue| to the passed in <var ignore>value</var>.
-
-       : [=internal observer/error steps=]
-       :: [=Reject=] |p| with the passed in <var ignore>error</var>.
-
-       : [=internal observer/complete steps=]
-       :: 1. If |hasLastValue| is true, [=resolve=] |p| with |lastValue|.
-
-          1. Otherwise, [=reject=] |p| with a [=new=] {{RangeError}}.
-
-    1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
-       and |options|.
 
     1. Return |p|.
 </div>


### PR DESCRIPTION
Reverts WICG/observable#133. It was landed prematurely. See https://github.com/WICG/observable/pull/131#issuecomment-2083248807 among other discussion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/143.html" title="Last updated on May 4, 2024, 6:47 PM UTC (92bbb3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/143/e6ee22b...92bbb3d.html" title="Last updated on May 4, 2024, 6:47 PM UTC (92bbb3d)">Diff</a>