### PR TITLE
Make take/drop not share state across subscriptions

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -770,8 +770,9 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
     1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+       1. Let |remaining| be |amount|.
 
-       1. If |amount| is 0, then run |subscriber|'s {{Subscriber/complete()}} method and abort
+       1. If |remaining| is 0, then run |subscriber|'s {{Subscriber/complete()}} method and abort
           these steps.
 
        1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
@@ -780,9 +781,9 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
           :: 1. Run |subscriber|'s {{Subscriber/next()}} method with the passed in <var
                 ignore>value</var>.
 
-             1. Decrement |amount|.
+             1. Decrement |remaining|.
 
-             1. If |amount| is 0, then run |subscriber|'s {{Subscriber/complete()}} method.
+             1. If |remaining| is 0, then run |subscriber|'s {{Subscriber/complete()}} method.
 
           : [=internal observer/error steps=]
           :: Run |subscriber|'s {{Subscriber/error()}} method, given the passed in <var
@@ -811,13 +812,14 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
     1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+       1. Let |remaining| be |amount|.
 
        1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
 
           : [=internal observer/next steps=]
-          :: 1. If |amount| is &gt; 0, then decrement |amount| and abort these steps.
+          :: 1. If |remaining| is &gt; 0, then decrement |remaining| and abort these steps.
 
-             1. [=Assert=]: |amount| is 0.
+             1. [=Assert=]: |remaining| is 0.
 
              1. Run |subscriber|'s {{Subscriber/next()}} method with the passed in <var
                 ignore>value</var>.


### PR DESCRIPTION
As spec-ed the behaviour of take/drop means this prints the values only once:

```js
const obs = Observable.from([1,2,3,4,5,6]);
const firstThree = obs.take(3);

firstThree.forEach((v) => {
    console.log(v);
});

// This doesn't print anything
firstThree.forEach((v) => {
    console.log(v);
});
```

The intended behaviour I would expect is that each subscription has it's own counter.

The fix provided here just makes a new variable local to each subscription rather than re-using the argument to take/drop.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Jamesernator/observable/pull/155.html" title="Last updated on Jul 11, 2024, 4:53 AM UTC (0316480)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/155/7b4cb07...Jamesernator:0316480.html" title="Last updated on Jul 11, 2024, 4:53 AM UTC (0316480)">Diff</a>