### PR TITLE
Rename `SubscriptionObserverCallback` to `ObservableSubscriptionCallback`

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -317,15 +317,15 @@ observable.subscribe({}, {signal: outerController.signal});
 // SubscribeCallback is where the Observable "creator's" code lives. It's
 // called when subscribe() is called, to set up a new subscription.
 callback SubscribeCallback = undefined (Subscriber subscriber);
-callback SubscriptionObserverCallback = undefined (any value);
+callback ObservableSubscriptionCallback = undefined (any value);
 
 dictionary SubscriptionObserver {
-  SubscriptionObserverCallback next;
-  SubscriptionObserverCallback error;
+  ObservableSubscriptionCallback next;
+  ObservableSubscriptionCallback error;
   VoidFunction complete;
 };
 
-typedef (SubscriptionObserverCallback or SubscriptionObserver) ObserverUnion;
+typedef (ObservableSubscriptionCallback or SubscriptionObserver) ObserverUnion;
 
 dictionary SubscribeOptions {
   AbortSignal signal;
@@ -464,7 +464,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        <ol id=process-observer>
          <li>
            <dl class="switch">
-             <dt>If |observer| is a {{SubscriptionObserverCallback}}</dt>
+             <dt>If |observer| is a {{ObservableSubscriptionCallback}}</dt>
              <dd>Set |internal observer|'s [=internal observer/next steps=] to these steps that take
                  an {{any}} |value|:
 

--- a/spec.bs
+++ b/spec.bs
@@ -464,7 +464,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        <ol id=process-observer>
          <li>
            <dl class="switch">
-             <dt>If |observer| is a {{ObservableSubscriptionCallback}}</dt>
+             <dt>If |observer| is an {{ObservableSubscriptionCallback}}</dt>
              <dd>Set |internal observer|'s [=internal observer/next steps=] to these steps that take
                  an {{any}} |value|:
 


### PR DESCRIPTION
@maraisr and I have renamed `SubscriptionObserverCallback` to `ObservableSubscriptionCallback` based on [review feedback from @rreno here](https://github.com/WebKit/WebKit/pull/23067#pullrequestreview-2178848864)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/157.html" title="Last updated on Jul 22, 2024, 7:57 AM UTC (54aa7ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/157/f954c91...54aa7ac.html" title="Last updated on Jul 22, 2024, 7:57 AM UTC (54aa7ac)">Diff</a>