### PR TITLE
Spec `from()` static converter

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -512,36 +512,41 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
          1. Let |nextPromise| be a {{Promise}}-or-undefined, initially undefined.
 
-         1. Let |nextRecord| be [$IteratorStepValue$](|iteratorRecord|).
+         1. Let |nextRecord| be [$IteratorNext$](|iteratorRecord|), and process it as follows:
 
-            Process |nextRecord| as follows:
+         1. If |nextRecord| is a [=throw completion=], then:
 
-            <dl class="switch">
-              <dt>If |nextRecord| is a [=throw completion=]</dt>
-              <dd>
-               <ol>
-                <li><p>[=Assert=]: |iteratorRecord|'s \[[Done]] is true.</p></li>
+            1. [=Assert=]: |iteratorRecord|'s \[[Done]] is true.
 
-                <li><p>Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
-               </ol>
-              </dd>
+            1. Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
 
-              <dt>If |nextRecord| is DONE</dt>
-              <dd>[=Queue a microtask=] to run |subscriber|'s {{Subscriber/complete()}} method, and
-              return from |nextAlgorithm|.
+         1. Otherwise, if |nextRecord| is [=normal completion=], then set |nextPromise| to [=a
+            promise resolved with=] |nextRecord|'s \[[Value]].
 
-              <dt>If |nextRecord| is [=normal completion=]</dt>
-              <dd>
-               <p>Set |nextPromise| to [=a promise resolved with=] |nextRecord|'s \[[Value]].</p>
-
-               Note: This is done in case |nextRecord|'s \[[Value]] is not *itself* already a {{Promise}}.
-            </dl>
+            Note: This is done in case |nextRecord|'s \[[Value]] is not *itself* already a
+            {{Promise}}.
 
          1. [=React=] to |nextPromise|:
 
-            1. If |nextPromise| was fulfilled with value |v|, then:
+            1. If |nextPromise| was fulfilled with value |iteratorResult|, then:
 
-               1. Run |subscriber|'s {{Subscriber/next()}} method, given |v|.
+               1. If [$Type$](|iteratorResult|) is not Object, then run |subscriber|'s
+                  {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
+
+               1. Let |done| be [$IteratorComplete$](iteratorResult).
+
+               1. If |done| is a [=throw completion=], then run |subscriber|'s
+                  {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
+
+                  Otherwise, if |done|'s \[[Value]] is true, then run |subscriber|'s
+                  {{Subscriber/complete()}} and abort these steps.
+
+               1. Let |value| be [$IteratorValue$](|iteratorResult).
+
+               1. If |value| is a [=throw completion=], then run |subscriber|'s
+                  {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
+
+               1. Run |subscriber|'s {{Subscriber/next()}} method, given |value|'s \[[Value]].
 
                1. Run |nextAlgorithm|, given |subscriber| and |iteratorRecord|.
 

--- a/spec.bs
+++ b/spec.bs
@@ -474,7 +474,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 </div>
 
 <div algorithm>
-  To <dfn for=Observable>convert to an Observable</dfn> given an {{any}} |value|, run these steps:
+  To <dfn for=Observable>convert to an Observable</dfn> an {{any}} |value|, run these steps:
 
   Note: We split this algorithm out from the Web IDL {{Observable/from()}} method, so that
   spec prose can <a for=Observable lt="convert to an observable">convert</a> an {{Observable}}
@@ -515,17 +515,32 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. Let |nextAlgorithm| be the following steps, given a {{Subscriber}} |subscriber| and an
        Iterator Record |iteratorRecord|:
 
-         1. If |iteratorRecord|'s \[[Done]] is true, then: run |subscriber|'s
-            {{Subscriber/complete()}} method and abort these steps.
+         1. Let |nextPromise| be a {{Promise}}-or-undefined, initially undefined.
 
          1. Let |nextRecord| be [$IteratorStepValue$](|iteratorRecord|).
 
-         1. Let |nextPromise| be undefined.
+            Process |nextRecord| as follows:
 
-         1. If |nextRecord| is a [=throw completion=], then set |nextPromise| to [=a promise
-            rejected with=] |nextRecord|'s \[[Value]].
+            <dl class="switch">
+              <dt>If |nextRecord| is a [=throw completion=]</dt>
+              <dd>
+               <ol>
+                <li><p>[=Assert=]: |iteratorRecord|'s \[[Done]] is true.</p></li>
 
-            Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
+                <li><p>Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
+               </ol>
+              </dd>
+
+              <dt>If |nextRecord| is DONE</dt>
+              <dd>[=Queue a microtask=] to run |subscriber|'s {{Subscriber/complete()}} method, and
+              return from |nextAlgorithm|.
+
+              <dt>If |nextRecord| is [=normal completion=]</dt>
+              <dd>
+               <p>Set |nextPromise| to [=a promise resolved with=] |nextRecord|'s \[[Value]].</p>
+
+               Note: This is done in case |nextRecord|'s \[[Value]] is not *itself* already a {{Promise}}.
+            </dl>
 
          1. [=React=] to |nextPromise|:
 
@@ -543,21 +558,27 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
        1. Let |iteratorRecord| be [$GetIterator$](|value|, async).
 
+          Note: This re-invokes any method getters for the {{%Symbol.iterator%}} method on |value|.
+          Whether or not this is desirable is an extreme corner case, but this behavior currently
+          matches what is expected by tests. See <a
+          href=https://github.com/WICG/observable/issues/127>issue#127</a> for discussion.
+
+
        1. If |iteratorRecord| is a [=throw completion=], then [=queue a microtask=] to run
           |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
 
-          Otherwise, [=queue a microtask=] to run |nextAlgorithm| given |subscriber| and
-          |iteratorRecord|.
+       1. [=Assert=]: |iteratorRecord| is an Iterator Record.
 
-       Note: It is important to [=queue a microtask=] in both branches here to guarantee that
-       coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing
-       Zalgo.
+       1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|.
+
+       Issue: In the error case immediately above, and in the DONE case in |nextAlgorithm|, we
+       [=queue a microtask=] to invoke relevant callbacks. This was done so that subscription to an
+       AsyncIterable-coerced {{Observable}} never invokes callbacks synchronously, "thereby
+       releasing Zalgo". But ordinary Observables are allowed to invoke callbacks synchronously
+       during subscription, so it is not clear if this is needed at all.
 
     1. <i id=from-iterable-conversion><b>From iterable</b></i>: Let |iteratorMethodRecord| be [=?=]
        [$GetMethod$](|value|, {{%Symbol.iterator%}}).
-
-       Note: This step is web-observable, and re-throws any errors that the {{%Symbol.iterator%}}
-       method *getter* might have thrown.
 
     1. If |iteratorMethodRecord|'s \[[Value]] is undefined or null, then jump to the step labeled <a
        href=#from-promise-conversion>From Promise</a>.
@@ -569,11 +590,6 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
          1. Let |iteratorRecord| be [$GetIterator$](|value|, sync).
-
-            Note: This re-invokes any method getters for the {{%Symbol.iterator%}} method on
-            |value|. Whether or not this is desirable is an extreme corner case, but this behavior
-            currently matches what is expected by tests. See <a
-            href=https://github.com/WICG/observable/issues/127>issue#127</a> for discussion.
 
          1. If |iteratorRecord| is a [=throw completion=], then run |subscriber|'s
             {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]], and abort these

--- a/spec.bs
+++ b/spec.bs
@@ -27,7 +27,6 @@ urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
   type: dfn
     text: current realm
     text: Object; url: sec-object-type
-    text: GetIteratorFromMethod; url: sec-getiteratorfrommethod
     text: IteratorStepValue; url: sec-iteratorstepvalue
     text: normal completion; url: sec-normalcompletion
     text: throw completion; url: sec-throwcompletion
@@ -494,11 +493,11 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        Issue: See if this is even the behavior we want. See <a
        href=https://github.com/WICG/observable/issues/125>WICG/observable#125</a>
 
-    1. <i id=from-observable-conversion>From Observable</i>: If |value|'s [=specific type=] is an
-       {{Observable}}, then return |value|.
+    1. <i id=from-observable-conversion><b>From Observable</b></i>: If |value|'s [=specific type=]
+       is an {{Observable}}, then return |value|.
 
-    1. <i id=from-async-iterable-conversion>From async iterator</i>: Let |asyncIteratorMethodRecord|
-       be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
+    1. <i id=from-async-iterable-conversion><b>From async iterator</b></i>: Let
+       |asyncIteratorMethodRecord| be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
 
        Note: We have to use [$GetMethod$] directly instead of [$GetIterator$], because
        [$GetIterator$] makes it impossible to distinguish between (a) the case where |value| simply
@@ -514,55 +513,53 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. If [$IsCallable$](|asyncIteratorMethodRecord|'s \[[Value]]) is false, then
        [=exception/throw=] a {{TypeError}}.
 
-       Otherwise:
+       Otherwise, let |nextAlgorithm| be the following steps, given |subscriber| and |iterator|:
 
-       1. Let |nextAlgorithm| be the following steps, given |subscriber| and |iterator|:
-
-          1. If |iterator|'s \[[Done]] is true, then:
+         1. If |iterator|'s \[[Done]] is true, then:
           
-             1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
+            1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
 
-          1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
+         1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
 
-          1. Let |nextPromise| be undefined.
+         1. Let |nextPromise| be undefined.
 
-          1.  If |nextRecord| is a [=throw completion=] then:
+         1.  If |nextRecord| is a [=throw completion=] then:
 
-              1. Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
+             1. Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
 
-          1. Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
+         1. Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
 
-          1. [=React=] to |nextPromise|:
+         1. [=React=] to |nextPromise|:
 
-             1. If |nextPromise| was fulfilled with value |v|, then:
+            1. If |nextPromise| was fulfilled with value |v|, then:
 
-                1. Run |subscriber|'s {{Subscriber/next()}} method, given |v|.
+               1. Run |subscriber|'s {{Subscriber/next()}} method, given |v|.
 
-                1. Run |nextAlgorithm|, given |subscriber| and |iterator|.
+               1. Run |nextAlgorithm|, given |subscriber| and |iterator|.
 
-             1. If |nextPromise| was rejected with reason |r|, then run |subscriber|'s
-                {{Subscriber/error()}} method, given |r|.
+            1. If |nextPromise| was rejected with reason |r|, then run |subscriber|'s
+               {{Subscriber/error()}} method, given |r|.
 
-       1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
-          algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+    1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an algorithm that
+       takes a {{Subscriber}} |subscriber| and does the following:
 
-          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, {{%Symbol.asyncIterator%}}).
+       1. Let |iteratorRecord| be [$GetIteratorFromMethod$](|value|, {{%Symbol.asyncIterator%}}).
 
-          1. If |iteratorRecord| is a [=throw completion=] then:
+       1. If |iteratorRecord| is a [=throw completion=] then:
 
-             1. [=Queue a microtask=] to perform the following steps:
+          1. [=Queue a microtask=] to perform the following steps:
 
-                1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
+             1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
 
-          1. Otherwise, [=queue a microtask=] to perform the following steps:
+       1. Otherwise, [=queue a microtask=] to perform the following steps:
 
-             1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|'s \[[Value]].
+          1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|'s \[[Value]].
 
-          Note: It is important to [=queue a microtask=] in both branches here to guarantee that
-          coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing
-          Zalgo.
+       Note: It is important to [=queue a microtask=] in both branches here to guarantee that
+       coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing
+       Zalgo.
 
-    1. <i id=from-iterable-conversion>From iterable</i>: Let |iteratorMethodRecord| be [=?=]
+    1. <i id=from-iterable-conversion><b>From iterable</b></i>: Let |iteratorMethodRecord| be [=?=]
        [$GetMethod$](|value|, {{%Symbol.iterator%}}).
 
        Note: This step is web-observable, and results in re-throwing any errors that the
@@ -574,40 +571,39 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. If [$IsCallable$](|iteratorMethodRecord|'s \[[Value]]) is false, then [=exception/throw=] a
        {{TypeError}}.
 
-       Otherwise:
+       Otherwise, return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+       algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
-       1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
-          algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+         1. Let |iteratorRecord| be [$GetIteratorFromMethod$](|value|, {{%Symbol.iterator%}}).
 
-          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, {{%Symbol.iterator%}}).
+         1. If |iteratorRecord| is a [=throw completion=] then:
 
-          1. If |iteratorRecord| is a [=throw completion=] then:
+            1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s
+               \[[Value]].
 
-             1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s
-                \[[Value]].
+            1. Abort these steps.
 
-             1. Abort these steps.
+         1. Let |iterator| be |iteratorRecord|'s \[[Value]].
 
-          1. Let |iterator| be |iteratorRecord|'s \[[Value]].
+         1. Repeat:
 
-          1. Repeat:
+            1. If |iterator|'s \[[Done]] is true, then:
 
-             1. If |iterator|'s \[[Done]] is true, then:
+               1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
 
-                1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
+            1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
 
-             1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
+            1. If |nextRecord| is a [=throw completion=] then:
 
-             1. If |nextRecord| is a [=throw completion=] then:
+               1. Run |subscriber|'s {{Subscriber/error()}} method, given |nextRecord|'s
+                  \[[Value]].
 
-                1. Run |subscriber|'s {{Subscriber/error()}} method, given |nextRecord|'s
-                   \[[Value]].
+               1. Abort these steps.
 
-                1. Abort these steps.
+            1. Run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
 
-             1. Run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
-
-    1. <i id=from-promise-conversion>From Promise</i>: If [$IsPromise$](|value|) is true, then:
+    1. <i id=from-promise-conversion><b>From Promise</b></i>: If [$IsPromise$](|value|) is true,
+       then:
 
        1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an algorithm
           that takes a {{Subscriber}} |subscriber| and does the following:

--- a/spec.bs
+++ b/spec.bs
@@ -482,7 +482,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
   Note: The resolution of value to its descrete types happens before
   [=Observable/subscribe callback=] is called. This means mutations of values, such as adding
-  the iterable protocols to the object, will not take affect between the creation of the returned
+  the iterable protocols to the object, will not take effect between the creation of the returned
   observable, and when it is subscribed to.
 
     1. If [$Type$](|value|) is not [=Object=], [=exception/throw=] a {{TypeError}}.

--- a/spec.bs
+++ b/spec.bs
@@ -480,11 +480,6 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
   spec prose can <a for=Observable lt="convert to an observable">convert</a> values to without
   going through the Web IDL bindings.
 
-  Note: The resolution of value to its descrete types happens before
-  [=Observable/subscribe callback=] is called. This means mutations of values, such as adding
-  the iterable protocols to the object, will not take effect between the creation of the returned
-  observable, and when it is subscribed to.
-
     1. If [$Type$](|value|) is not [=Object=], [=exception/throw=] a {{TypeError}}.
 
        Note: This prevents primitive types from being coerced into iterables (e.g., String).

--- a/spec.bs
+++ b/spec.bs
@@ -536,7 +536,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
                1. Let |done| be [$IteratorComplete$](|iteratorResult|).
 
                1. If |done| is a [=throw completion=], then run |subscriber|'s
-                  {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
+                  {{Subscriber/error()}} method with |done|'s \[[Value]] and abort these steps.
 
                   Otherwise, if |done|'s \[[Value]] is true, then run |subscriber|'s
                   {{Subscriber/complete()}} and abort these steps.
@@ -544,7 +544,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
                1. Let |value| be [$IteratorValue$](|iteratorResult|).
 
                1. If |value| is a [=throw completion=], then run |subscriber|'s
-                  {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
+                  {{Subscriber/error()}} method with |value|'s \[[Value]] and abort these steps.
 
                1. Run |subscriber|'s {{Subscriber/next()}} method, given |value|'s \[[Value]].
 

--- a/spec.bs
+++ b/spec.bs
@@ -579,7 +579,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
           algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
-          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, %Symbol.iterator%).
+          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, {{%Symbol.iterator%}}).
 
           1. If |iteratorRecord| is a [=throw completion=] then:
 

--- a/spec.bs
+++ b/spec.bs
@@ -512,19 +512,20 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. If [$IsCallable$](|asyncIteratorMethodRecord|'s \[[Value]]) is false, then
        [=exception/throw=] a {{TypeError}}.
 
-       Otherwise, let |nextAlgorithm| be the following steps, given |subscriber| and |iterator|:
+    1. Let |nextAlgorithm| be the following steps, given a {{Subscriber}} |subscriber| and an
+       Iterator Record |iteratorRecord|:
 
-         1. If |iterator|'s \[[Done]] is true, then: run |subscriber|'s {{Subscriber/complete()}}
-            method and abort these steps.
+         1. If |iteratorRecord|'s \[[Done]] is true, then: run |subscriber|'s
+            {{Subscriber/complete()}} method and abort these steps.
 
-         1. Let |nextRecord| be [$IteratorStepValue$](|iterator|).
+         1. Let |nextRecord| be [$IteratorStepValue$](|iteratorRecord|).
 
          1. Let |nextPromise| be undefined.
 
-         1.  If |nextRecord| is a [=throw completion=], then set |nextPromise| to [=a promise
-             rejected with=] |nextRecord|'s \[[Value]].
+         1. If |nextRecord| is a [=throw completion=], then set |nextPromise| to [=a promise
+            rejected with=] |nextRecord|'s \[[Value]].
 
-         1. Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
+            Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
 
          1. [=React=] to |nextPromise|:
 
@@ -532,7 +533,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
                1. Run |subscriber|'s {{Subscriber/next()}} method, given |v|.
 
-               1. Run |nextAlgorithm|, given |subscriber| and |iterator|.
+               1. Run |nextAlgorithm|, given |subscriber| and |iteratorRecord|.
 
             1. If |nextPromise| was rejected with reason |r|, then run |subscriber|'s
                {{Subscriber/error()}} method, given |r|.
@@ -545,8 +546,8 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        1. If |iteratorRecord| is a [=throw completion=], then [=queue a microtask=] to run
           |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
 
-       1. Otherwise, [=queue a microtask=] to run |nextAlgorithm| given |subscriber| and
-          |iteratorRecord|'s \[[Value]].
+          Otherwise, [=queue a microtask=] to run |nextAlgorithm| given |subscriber| and
+          |iteratorRecord|.
 
        Note: It is important to [=queue a microtask=] in both branches here to guarantee that
        coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing

--- a/spec.bs
+++ b/spec.bs
@@ -540,7 +540,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an algorithm that
        takes a {{Subscriber}} |subscriber| and does the following:
 
-       1. Let |iteratorRecord| be [$GetIteratorFromMethod$](|value|, {{%Symbol.asyncIterator%}}).
+       1. Let |iteratorRecord| be [$GetIterator$](|value|, async).
 
        1. If |iteratorRecord| is a [=throw completion=], then [=queue a microtask=] to run
           |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].

--- a/spec.bs
+++ b/spec.bs
@@ -26,13 +26,15 @@ WPT Display: open
 urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
   type: dfn
     text: current realm
-    text: an Object; url: sec-object-type
-    text: IsPromise; url: sec-ispromise
-    text: GetMethod; url: sec-getmethod
+    text: Object; url: sec-object-type
     text: GetIteratorFromMethod; url: sec-getiteratorfrommethod
     text: IteratorStepValue; url: sec-iteratorstepvalue
     text: normal completion; url: sec-normalcompletion
     text: throw completion; url: sec-throwcompletion
+    url: sec-returnifabrupt-shorthands
+      text: ?
+  type: abstract-op
+    text: Type; url: sec-ecmascript-data-types-and-values
 urlPrefix: https://dom.spec.whatwg.org; spec: DOM
   type: dfn
     for: event listener
@@ -485,18 +487,24 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
   the iterable protocols to the object, will not take affect between the creation of the returned
   observable, and when it is subscribed to.
 
-    1. If |value| is not [=an Object=], throw a {{TypeError}}.
+    1. If [$Type$](|value|) is not [=Object=], [=exception/throw=] a {{TypeError}}.
 
-    Note: This prevents primitive types from being coerced into iterables (e.g. String).
+       Note: This prevents primitive types from being coerced into iterables (e.g., String).
 
-    1. If |value| is an {{Observable}}, then return |value|.
+       Issue: See if this is even the behavior we want. See <a
+       href=https://github.com/WICG/observable/issues/125>WICG/observable#125</a>
 
-    1. Let |asyncIteratorMethodRecord| be ? [=GetMethod=](|value|, %Symbol.asyncIterator%).
+    1. If |value|'s [=specific type=] is an {{Observable}}, then return |value|.
+
+    1. Let |asyncIteratorMethodRecord| be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
+
+       Issue: TODO(dom or keith): This looks wrong. We certainly cannot return abrupt completions
+       from this method directly to JS.
 
     1. If |asyncIteratorMethodRecord|'s \[[Value]] is not undefined, then:
 
-       Note: [=GetMethod=] might return a [=normal completion=] with an undefined value when the
-       object simply has no asyncIterator method.
+       Note: [$GetMethod$] might return a [=normal completion=] with an undefined value when the
+       object simply has no {{%Symbol.asyncIterator%}} method.
 
        1. Let |nextAlgorithm| be the following steps, given |subscriber| and |iterator|:
 
@@ -514,7 +522,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
           1. Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
 
-          1. React to |nextPromise|:
+          1. [=React=] to |nextPromise|:
 
              1. If |nextPromise| was fulfilled with value |v|, then:
 
@@ -528,11 +536,11 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
           algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
-          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, %Symbol.asyncIterator%).
+          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, {{%Symbol.asyncIterator%}}).
 
           1. If |iteratorRecord| is a [=throw completion=] then:
 
-             1. [=queue a microtask=] to perform the following steps:
+             1. [=Queue a microtask=] to perform the following steps:
 
                 1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
 
@@ -544,11 +552,13 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
           coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing
           Zalgo.
 
-    1. Let |iteratorMethodRecord| be ? [=GetMethod=](|value|, %Symbol.iterator%).
+    1. Let |iteratorMethodRecord| be [=?=] [$GetMethod$](|value|, %Symbol.iterator%).
+
+       Issue: TODO(dom or keith): Same issue as above with abrupt (throw) completions.
 
     1. If |iteratorMethodRecord|'s \[[Value]] is not undefined, then:
 
-       Note: [=GetMethod=] might return a [=normal completion=] with an undefined value when the
+       Note: [$GetMethod$] might return a [=normal completion=] with an undefined value when the
        object simply has no asyncIterator method.
 
        1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
@@ -580,12 +590,12 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
              1. Run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
 
-    1. If [=IsPromise=](|value|) is true, then:
+    1. If [$IsPromise$](|value|) is true, then:
 
-       1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
-          algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+       1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an algorithm
+          that takes a {{Subscriber}} |subscriber| and does the following:
 
-          1. React to |value|:
+          1. [=React=] to |value|:
 
              1. If |value| was fulfilled with value |v|, then:
 
@@ -596,8 +606,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
              1. If |value| was rejected with reason |r|, then run |subscriber|'s
                 {{Subscriber/error()}} method, given |r|.
 
-    1. Throw a {{TypeError}}.
-
+    1. [=exception/Throw=] a {{TypeError}}.
 </div>
 
 <div algorithm>
@@ -717,12 +726,10 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 <h4 id=observable-from>{{Observable/from()}}</h4>
 
 <div algorithm>
-  The <dfn for=Observable method><code>from(|value|)</code></dfn> method steps
-  are:
+  The <dfn for=Observable method><code>from(|value|)</code></dfn> method steps are:
 
-    1. Return the result of <a for=Observable lt="convert to an Observable">
-       converting</a> |value| to an Observable.
-
+    1. Return the result of <a for=Observable lt="convert to an Observable">converting</a> |value|
+       to an {{Observable}}. Rethrow any exceptions.
 </div>
 
 <h4 id=observable-returning-operators>{{Observable}}-returning operators</h4>

--- a/spec.bs
+++ b/spec.bs
@@ -27,7 +27,6 @@ urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
   type: dfn
     text: current realm
     text: Object; url: sec-object-type
-    text: IteratorStepValue; url: sec-iteratorstepvalue
     text: normal completion; url: sec-normalcompletion
     text: throw completion; url: sec-throwcompletion
     url: sec-returnifabrupt-shorthands
@@ -519,7 +518,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
           
             1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
 
-         1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
+         1. Let |nextRecord| be [$IteratorStepValue$](|iterator|).
 
          1. Let |nextPromise| be undefined.
 
@@ -574,33 +573,31 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        Otherwise, return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
-         1. Let |iteratorRecord| be [$GetIteratorFromMethod$](|value|, {{%Symbol.iterator%}}).
+         1. Let |iteratorRecord| be [$GetIterator$](|value|, sync).
 
-         1. If |iteratorRecord| is a [=throw completion=] then:
+            Note: This re-invokes any method getters for the {{%Symbol.iterator%}} method on
+            |value|. Whether or not this is desirable is an extreme corner case, but this behavior
+            currently matches what is expected by tests. See <a
+            href=https://github.com/WICG/observable/issues/127>issue#127</a> for discussion.
 
-            1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s
-               \[[Value]].
-
-            1. Abort these steps.
+         1. If |iteratorRecord| is a [=throw completion=], then run |subscriber|'s
+            {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]], and abort these
+            steps.
 
          1. Let |iterator| be |iteratorRecord|'s \[[Value]].
 
-         1. Repeat:
+         1. [=iteration/While=] true:
 
-            1. If |iterator|'s \[[Done]] is true, then:
+            1. If |iterator|'s \[[Done]] is true, then run |subscriber|'s {{Subscriber/complete()}}
+               method, and [=iteration/break=].
 
-               1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
+            1. Let |nextRecord| be [$IteratorStepValue$](|iterator|).
 
-            1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
+            1. If |nextRecord| is a [=throw completion=], then run |subscriber|'s
+               {{Subscriber/error()}} method, given |nextRecord|'s \[[Value]], and
+               [=iteration/break=].
 
-            1. If |nextRecord| is a [=throw completion=] then:
-
-               1. Run |subscriber|'s {{Subscriber/error()}} method, given |nextRecord|'s
-                  \[[Value]].
-
-               1. Abort these steps.
-
-            1. Run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
+               Otherwise, run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
 
     1. <i id=from-promise-conversion><b>From Promise</b></i>: If [$IsPromise$](|value|) is true,
        then:

--- a/spec.bs
+++ b/spec.bs
@@ -503,8 +503,8 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        doesn't implement any iterable protocol, and (b) the case where |value| implements one of the
        iterator protocols, and its method getter throws an exception.
 
-       Note: This step is web-observable, and results in re-throwing any errors that the
-       {{%Symbol.iterator%}} method *getter* might have thrown.
+       Note: This step is web-observable, and re-throws any errors that the {{%Symbol.iterator%}}
+       method *getter* might have thrown.
 
     1. If |asyncIteratorMethodRecord|'s \[[Value]] is undefined or null, then jump to the step
        labeled <a href=#from-iterable-conversion>From iterable</a>.
@@ -514,17 +514,15 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
        Otherwise, let |nextAlgorithm| be the following steps, given |subscriber| and |iterator|:
 
-         1. If |iterator|'s \[[Done]] is true, then:
-          
-            1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
+         1. If |iterator|'s \[[Done]] is true, then: run |subscriber|'s {{Subscriber/complete()}}
+            method and abort these steps.
 
          1. Let |nextRecord| be [$IteratorStepValue$](|iterator|).
 
          1. Let |nextPromise| be undefined.
 
-         1.  If |nextRecord| is a [=throw completion=] then:
-
-             1. Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
+         1.  If |nextRecord| is a [=throw completion=], then set |nextPromise| to [=a promise
+             rejected with=] |nextRecord|'s \[[Value]].
 
          1. Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
 
@@ -544,15 +542,11 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
        1. Let |iteratorRecord| be [$GetIteratorFromMethod$](|value|, {{%Symbol.asyncIterator%}}).
 
-       1. If |iteratorRecord| is a [=throw completion=] then:
+       1. If |iteratorRecord| is a [=throw completion=], then [=queue a microtask=] to run
+          |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
 
-          1. [=Queue a microtask=] to perform the following steps:
-
-             1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
-
-       1. Otherwise, [=queue a microtask=] to perform the following steps:
-
-          1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|'s \[[Value]].
+       1. Otherwise, [=queue a microtask=] to run |nextAlgorithm| given |subscriber| and
+          |iteratorRecord|'s \[[Value]].
 
        Note: It is important to [=queue a microtask=] in both branches here to guarantee that
        coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing
@@ -561,8 +555,8 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. <i id=from-iterable-conversion><b>From iterable</b></i>: Let |iteratorMethodRecord| be [=?=]
        [$GetMethod$](|value|, {{%Symbol.iterator%}}).
 
-       Note: This step is web-observable, and results in re-throwing any errors that the
-       {{%Symbol.iterator%}} method *getter* might have thrown.
+       Note: This step is web-observable, and re-throws any errors that the {{%Symbol.iterator%}}
+       method *getter* might have thrown.
 
     1. If |iteratorMethodRecord|'s \[[Value]] is undefined or null, then jump to the step labeled <a
        href=#from-promise-conversion>From Promise</a>.

--- a/spec.bs
+++ b/spec.bs
@@ -26,6 +26,13 @@ WPT Display: open
 urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
   type: dfn
     text: current realm
+    text: an Object; url: sec-object-type
+    text: IsPromise; url: sec-ispromise
+    text: GetMethod; url: sec-getmethod
+    text: GetIteratorFromMethod; url: sec-getiteratorfrommethod
+    text: IteratorStepValue; url: sec-iteratorstepvalue
+    text: normal completion; url: sec-normalcompletion
+    text: throw completion; url: sec-throwcompletion
 urlPrefix: https://dom.spec.whatwg.org; spec: DOM
   type: dfn
     for: event listener
@@ -38,6 +45,11 @@ urlPrefix: https://dom.spec.whatwg.org; spec: DOM
       text: dependent signals; url: abortsignal-dependent-signals
       text: signal abort; url:abortsignal-signal-abort
       text: abort reason; url:abortsignal-abort-reason
+urlPrefix: https://webidl.spec.whatwg.org; spec: WEBIDL
+  type: dfn
+    text: a promise rejected with
+  type: dfn
+    text: react
 </pre>
 
 <style>
@@ -371,7 +383,7 @@ interface Observable {
   //
   // takeUntil() can consume promises, iterables, async iterables, and other
   // observables.
-  Observable takeUntil(any notifier);
+  Observable takeUntil(any value);
   Observable map(Mapper mapper);
   Observable filter(Predicate predicate);
   Observable take(unsigned long long amount);
@@ -459,6 +471,133 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
   Observable">subscribes</a> to an {{Observable}}, these "steps" are arbitrary spec algorithms that
   are not provided via an {{ObserverUnion}} packed with Web IDL [=callback functions=]. See the
   [[#promise-returning-operators]] that make use of this, for example.</p>
+</div>
+
+<div algorithm>
+  To <dfn for=Observable>convert to an Observable</dfn> given an {{any}} |value|, run these steps:
+
+  Note: We split this algorithm out from the Web IDL {{Observable/from()}} method, so that
+  spec prose can <a for=Observable lt="convert to an observable">convert</a> an {{Observable}}
+  without going through the Web IDL bindings.
+
+  Note: The resolution of value to its descrete types happens before
+  [=Observable/subscribe callback=] is called. This means mutations of values, such as adding
+  the iterable protocols to the object, will not take affect between the creation of the returned
+  observable, and when it is subscribed to.
+
+    1. If |value| is not [=an Object=], throw a {{TypeError}}.
+
+    Note: This prevents primitive types from being coerced into iterables (e.g. String).
+
+    1. If |value| is an {{Observable}}, then return |value|.
+
+    1. Let |asyncIteratorMethodRecord| be ? [=GetMethod=](|value|, %Symbol.asyncIterator%).
+
+    1. If |asyncIteratorMethodRecord|'s \[[Value]] is not undefined, then:
+
+       Note: [=GetMethod=] might return a [=normal completion=] with an undefined value when the
+       object simply has no asyncIterator method.
+
+       1. Let |nextAlgorithm| be the following steps, given |subscriber| and |iterator|:
+
+          1. If |iterator|'s \[[Done]] is true, then:
+          
+             1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
+
+          1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
+
+          1. Let |nextPromise| be undefined.
+
+          1.  If |nextRecord| is a [=throw completion=] then:
+
+              1. Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
+
+          1. Otherwise, set |nextPromise| to |nextRecord|'s \[[Value]].
+
+          1. React to |nextPromise|:
+
+             1. If |nextPromise| was fulfilled with value |v|, then:
+
+                1. Run |subscriber|'s {{Subscriber/next()}} method, given |v|.
+
+                1. Run |nextAlgorithm|, given |subscriber| and |iterator|.
+
+             1. If |nextPromise| was rejected with reason |r|, then run |subscriber|'s
+                {{Subscriber/error()}} method, given |r|.
+
+       1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+          algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+
+          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, %Symbol.asyncIterator%).
+
+          1. If |iteratorRecord| is a [=throw completion=] then:
+
+             1. [=queue a microtask=] to perform the following steps:
+
+                1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
+
+          1. Otherwise, [=queue a microtask=] to perform the following steps:
+
+             1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|'s \[[Value]].
+
+          Note: It is important to [=queue a microtask=] in both branches here to guarantee that
+          coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing
+          Zalgo.
+
+    1. Let |iteratorMethodRecord| be ? [=GetMethod=](|value|, %Symbol.iterator%).
+
+    1. If |iteratorMethodRecord|'s \[[Value]] is not undefined, then:
+
+       Note: [=GetMethod=] might return a [=normal completion=] with an undefined value when the
+       object simply has no asyncIterator method.
+
+       1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+          algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+
+          1. Let |iteratorRecord| be [=GetIteratorFromMethod=](|value|, %Symbol.iterator%).
+
+          1. If |iteratorRecord| is a [=throw completion=] then:
+
+             1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
+
+             1. Abort these steps.
+
+          1. Let |iterator| be |iteratorRecord|'s \[[Value]].
+
+          1. Repeat:
+
+             1. If |iterator|'s \[[Done]] is true, then:
+
+                1. Run |subscriber|'s {{Subscriber/complete()}} method and abort these steps.
+
+             1. Let |nextRecord| be [=IteratorStepValue=](|iterator|).
+
+             1. If |nextRecord| is a [=throw completion=] then:
+
+                1. Run |subscriber|'s {{Subscriber/error()}} method, given |nextRecord|'s \[[Value]].
+
+                1. Abort these steps.
+
+             1. Run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
+
+    1. If [=IsPromise=](|value|) is true, then:
+
+       1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+          algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+
+          1. React to |value|:
+
+             1. If |value| was fulfilled with value |v|, then:
+
+                1. Run |subscriber|'s {{Subscriber/next()}} method, given |v|.
+
+                1. Run |subscriber|'s {{Subscriber/complete()}} method.
+
+             1. If |value| was rejected with reason |r|, then run |subscriber|'s
+                {{Subscriber/error()}} method, given |r|.
+
+    1. Throw a {{TypeError}}.
+
 </div>
 
 <div algorithm>
@@ -577,14 +716,24 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
 <h4 id=observable-from>{{Observable/from()}}</h4>
 
-<p class=XXX>Spec the exact semantics of {{Observable/from()}} conversion.</p>
+<div algorithm>
+  The <dfn for=Observable method><code>from(|value|)</code></dfn> method steps
+  are:
+
+    1. Return the result of <a for=Observable lt="convert to an Observable">
+       converting</a> |value| to an Observable.
+
+</div>
 
 <h4 id=observable-returning-operators>{{Observable}}-returning operators</h4>
 
 <div algorithm>
-  The <dfn for=Observable method><code>takeUntil(|notifier|)</code></dfn> method steps are:
+  The <dfn for=Observable method><code>takeUntil(|value|)</code></dfn> method steps are:
 
     1. Let |sourceObservable| be [=this=].
+
+    1. Let |notifier| be the result of <a for=Observable lt="convert to an Observable">
+       converting</a> |value| to an Observable.
 
     1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:

--- a/spec.bs
+++ b/spec.bs
@@ -477,8 +477,8 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
   To <dfn for=Observable>convert to an Observable</dfn> an {{any}} |value|, run these steps:
 
   Note: We split this algorithm out from the Web IDL {{Observable/from()}} method, so that
-  spec prose can <a for=Observable lt="convert to an observable">convert</a> an {{Observable}}
-  without going through the Web IDL bindings.
+  spec prose can <a for=Observable lt="convert to an observable">convert</a> values to without
+  going through the Web IDL bindings.
 
   Note: The resolution of value to its descrete types happens before
   [=Observable/subscribe callback=] is called. This means mutations of values, such as adding

--- a/spec.bs
+++ b/spec.bs
@@ -563,19 +563,21 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
           matches what is expected by tests. See <a
           href=https://github.com/WICG/observable/issues/127>issue#127</a> for discussion.
 
+       1. If |iteratorRecord| is a [=throw completion=], then run |subscriber|'s
+          {{Subscriber/error()}} method with |iteratorRecord|'s \[[Value]].
 
-       1. If |iteratorRecord| is a [=throw completion=], then [=queue a microtask=] to run
-          |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
+          Note: This means we invoke the {{Subscriber/error()}} method synchronously with respect to
+          subscription, which is the only time this can happen for async iterables that are
+          converted to {{Observable}}s. In all other cases, errors are propagated to the observer
+          asynchronously, with microtask timing, by virtue of being wrapped in a rejected
+          {{Promise}} that |nextAlgorithm| [=reacts=] to. This synchronous-error-propagation
+          behavior is hopefully OK, since it is consistent with language constructs (i.e.,
+          **for-await of** loops) that invoke {{%Symbol.asyncIterator%}} and synchronously re-throw
+          exceptions to catch blocks outside the loop, before any [$Await$]ing takes place.
 
        1. [=Assert=]: |iteratorRecord| is an Iterator Record.
 
        1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|.
-
-       Issue: In the error case immediately above, and in the DONE case in |nextAlgorithm|, we
-       [=queue a microtask=] to invoke relevant callbacks. This was done so that subscription to an
-       AsyncIterable-coerced {{Observable}} never invokes callbacks synchronously, "thereby
-       releasing Zalgo". But ordinary Observables are allowed to invoke callbacks synchronously
-       during subscription, so it is not clear if this is needed at all.
 
     1. <i id=from-iterable-conversion><b>From iterable</b></i>: Let |iteratorMethodRecord| be [=?=]
        [$GetMethod$](|value|, {{%Symbol.iterator%}}).

--- a/spec.bs
+++ b/spec.bs
@@ -498,9 +498,6 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
     1. Let |asyncIteratorMethodRecord| be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
 
-       Issue: TODO(dom or keith): This looks wrong. We certainly cannot return abrupt completions
-       from this method directly to JS.
-
     1. If |asyncIteratorMethodRecord|'s \[[Value]] is not undefined, then:
 
        Note: [$GetMethod$] might return a [=normal completion=] with an undefined value when the
@@ -553,8 +550,6 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
           Zalgo.
 
     1. Let |iteratorMethodRecord| be [=?=] [$GetMethod$](|value|, %Symbol.iterator%).
-
-       Issue: TODO(dom or keith): Same issue as above with abrupt (throw) completions.
 
     1. If |iteratorMethodRecord|'s \[[Value]] is not undefined, then:
 

--- a/spec.bs
+++ b/spec.bs
@@ -31,6 +31,7 @@ urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
     text: throw completion; url: sec-throwcompletion
     url: sec-returnifabrupt-shorthands
       text: ?
+      text: !
   type: abstract-op
     text: Type; url: sec-ecmascript-data-types-and-values
 urlPrefix: https://dom.spec.whatwg.org; spec: DOM
@@ -482,135 +483,50 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
     1. If [$Type$](|value|) is not [=Object=], [=exception/throw=] a {{TypeError}}.
 
-       Note: This prevents primitive types from being coerced into iterables (e.g., String).
-
-       Issue: See if this is even the behavior we want. See <a
-       href=https://github.com/WICG/observable/issues/125>WICG/observable#125</a>
+       Note: This prevents primitive types from being coerced into iterables (e.g., String). See
+       discussion in <a href=https://github.com/WICG/observable/issues/125>WICG/observable#125</a>.
 
     1. <i id=from-observable-conversion><b>From Observable</b></i>: If |value|'s [=specific type=]
        is an {{Observable}}, then return |value|.
 
-    1. <i id=from-async-iterable-conversion><b>From async iterator</b></i>: Let
-       |asyncIteratorMethodRecord| be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
+    1. Issue: Spec the <i><b>From async iterable</b></i> conversion steps which take place before
+       the iterable conversion steps.
 
-       Note: We have to use [$GetMethod$] directly instead of [$GetIterator$], because
-       [$GetIterator$] makes it impossible to distinguish between (a) the case where |value| simply
-       doesn't implement any iterable protocol, and (b) the case where |value| implements one of the
-       iterator protocols, and its method getter throws an exception.
-
-       Note: This step is web-observable, and re-throws any errors that the {{%Symbol.iterator%}}
-       method *getter* might have thrown.
-
-    1. If |asyncIteratorMethodRecord|'s \[[Value]] is undefined or null, then jump to the step
-       labeled <a href=#from-iterable-conversion>From iterable</a>.
-
-    1. If [$IsCallable$](|asyncIteratorMethodRecord|'s \[[Value]]) is false, then
-       [=exception/throw=] a {{TypeError}}.
-
-    1. Let |nextAlgorithm| be the following steps, given a {{Subscriber}} |subscriber| and an
-       Iterator Record |iteratorRecord|:
-
-         1. Let |nextPromise| be a {{Promise}}-or-undefined, initially undefined.
-
-         1. Let |nextRecord| be [$IteratorNext$](|iteratorRecord|), and process it as follows:
-
-         1. If |nextRecord| is a [=throw completion=], then:
-
-            1. [=Assert=]: |iteratorRecord|'s \[[Done]] is true.
-
-            1. Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
-
-         1. Otherwise, if |nextRecord| is [=normal completion=], then set |nextPromise| to [=a
-            promise resolved with=] |nextRecord|'s \[[Value]].
-
-            Note: This is done in case |nextRecord|'s \[[Value]] is not *itself* already a
-            {{Promise}}.
-
-         1. [=React=] to |nextPromise|:
-
-            1. If |nextPromise| was fulfilled with value |iteratorResult|, then:
-
-               1. If [$Type$](|iteratorResult|) is not Object, then run |subscriber|'s
-                  {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
-
-               1. Let |done| be [$IteratorComplete$](|iteratorResult|).
-
-               1. If |done| is a [=throw completion=], then run |subscriber|'s
-                  {{Subscriber/error()}} method with |done|'s \[[Value]] and abort these steps.
-
-                  Otherwise, if |done|'s \[[Value]] is true, then run |subscriber|'s
-                  {{Subscriber/complete()}} and abort these steps.
-
-               1. Let |value| be [$IteratorValue$](|iteratorResult|).
-
-               1. If |value| is a [=throw completion=], then run |subscriber|'s
-                  {{Subscriber/error()}} method with |value|'s \[[Value]] and abort these steps.
-
-               1. Run |subscriber|'s {{Subscriber/next()}} method, given |value|'s \[[Value]].
-
-               1. Run |nextAlgorithm|, given |subscriber| and |iteratorRecord|.
-
-            1. If |nextPromise| was rejected with reason |r|, then run |subscriber|'s
-               {{Subscriber/error()}} method, given |r|.
-
-    1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an algorithm that
-       takes a {{Subscriber}} |subscriber| and does the following:
-
-       1. Let |iteratorRecord| be [$GetIterator$](|value|, async).
-
-          Note: This re-invokes any method getters for the {{%Symbol.iterator%}} method on |value|.
-          Whether or not this is desirable is an extreme corner case, but this behavior currently
-          matches what is expected by tests. See <a
-          href=https://github.com/WICG/observable/issues/127>issue#127</a> for discussion.
-
-       1. If |iteratorRecord| is a [=throw completion=], then run |subscriber|'s
-          {{Subscriber/error()}} method with |iteratorRecord|'s \[[Value]].
-
-          Note: This means we invoke the {{Subscriber/error()}} method synchronously with respect to
-          subscription, which is the only time this can happen for async iterables that are
-          converted to {{Observable}}s. In all other cases, errors are propagated to the observer
-          asynchronously, with microtask timing, by virtue of being wrapped in a rejected
-          {{Promise}} that |nextAlgorithm| [=reacts=] to. This synchronous-error-propagation
-          behavior is hopefully OK, since it is consistent with language constructs (i.e.,
-          **for-await of** loops) that invoke {{%Symbol.asyncIterator%}} and synchronously re-throw
-          exceptions to catch blocks outside the loop, before any [$Await$]ing takes place.
-
-       1. [=Assert=]: |iteratorRecord| is an Iterator Record.
-
-       1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|.
-
-    1. <i id=from-iterable-conversion><b>From iterable</b></i>: Let |iteratorMethodRecord| be [=?=]
+    1. <i id=from-iterable-conversion><b>From iterable</b></i>: Let |iteratorMethod| be [=?=]
        [$GetMethod$](|value|, {{%Symbol.iterator%}}).
 
-    1. If |iteratorMethodRecord|'s \[[Value]] is undefined or null, then jump to the step labeled <a
+    1. If |iteratorMethod| is undefined, then jump to the step labeled <a
        href=#from-promise-conversion>From Promise</a>.
-
-    1. If [$IsCallable$](|iteratorMethodRecord|'s \[[Value]]) is false, then [=exception/throw=] a
-       {{TypeError}}.
 
        Otherwise, return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
-         1. Let |iteratorRecord| be [$GetIterator$](|value|, sync).
+         1. Let |iteratorRecordCompletion| be [$GetIterator$](|value|, sync).
 
-         1. If |iteratorRecord| is a [=throw completion=], then run |subscriber|'s
-            {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]], and abort these
-            steps.
+         1. If |iteratorRecordCompletion| is a [=throw completion=], then run |subscriber|'s
+            {{Subscriber/error()}} method, given |iteratorRecordCompletion|'s \[[Value]], and abort
+            these steps.
 
-         1. Let |iterator| be |iteratorRecord|'s \[[Value]].
+         1. Let |iteratorRecord| be [=!=] |iteratorRecordCompletion|.
 
          1. [=iteration/While=] true:
 
-            1. If |iterator|'s \[[Done]] is true, then run |subscriber|'s {{Subscriber/complete()}}
-               method, and [=iteration/break=].
+            1. Let |next| be [$IteratorStepValue$](|iteratorRecord|).
 
-            1. Let |nextRecord| be [$IteratorStepValue$](|iterator|).
+            1. If |next| is a [=throw completion=], then run |subscriber|'s {{Subscriber/error()}}
+               method, given |next|'s \[[Value]], and [=iteration/break=].
 
-            1. If |nextRecord| is a [=throw completion=], then run |subscriber|'s
-               {{Subscriber/error()}} method, given |nextRecord|'s \[[Value]], and
-               [=iteration/break=].
+            1. Set |next| to [=!=] to |next|.
 
-               Otherwise, run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
+            1. If |next| is done, then:
+
+               1. [=Assert=]: |iteratorRecord|'s \[[Done]] is true.
+
+               2. Run |subscriber|'s {{Subscriber/complete()}}.
+
+               3. Return.
+
+            1. Run |subscriber|'s {{Subscriber/next()}} given |next|.
 
     1. <i id=from-promise-conversion><b>From Promise</b></i>: If [$IsPromise$](|value|) is true,
        then:

--- a/spec.bs
+++ b/spec.bs
@@ -494,14 +494,27 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        Issue: See if this is even the behavior we want. See <a
        href=https://github.com/WICG/observable/issues/125>WICG/observable#125</a>
 
-    1. If |value|'s [=specific type=] is an {{Observable}}, then return |value|.
+    1. <i id=from-observable-conversion>From Observable</i>: If |value|'s [=specific type=] is an
+       {{Observable}}, then return |value|.
 
-    1. Let |asyncIteratorMethodRecord| be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
+    1. <i id=from-async-iterable-conversion>From async iterator</i>: Let |asyncIteratorMethodRecord|
+       be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
 
-    1. If |asyncIteratorMethodRecord|'s \[[Value]] is not undefined, then:
+       Note: We have to use [$GetMethod$] directly instead of [$GetIterator$], because
+       [$GetIterator$] makes it impossible to distinguish between (a) the case where |value| simply
+       doesn't implement any iterable protocol, and (b) the case where |value| implements one of the
+       iterator protocols, and its method getter throws an exception.
 
-       Note: [$GetMethod$] might return a [=normal completion=] with an undefined value when the
-       object simply has no {{%Symbol.asyncIterator%}} method.
+       Note: This step is web-observable, and results in re-throwing any errors that the
+       {{%Symbol.iterator%}} method *getter* might have thrown.
+
+    1. If |asyncIteratorMethodRecord|'s \[[Value]] is undefined or null, then jump to the step
+       labeled <a href=#from-iterable-conversion>From iterable</a>.
+
+    1. If [$IsCallable$](|asyncIteratorMethodRecord|'s \[[Value]]) is false, then
+       [=exception/throw=] a {{TypeError}}.
+
+       Otherwise:
 
        1. Let |nextAlgorithm| be the following steps, given |subscriber| and |iterator|:
 
@@ -549,12 +562,19 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
           coercing an AsyncIterable never stops the Subscription synchronously, thereby releasing
           Zalgo.
 
-    1. Let |iteratorMethodRecord| be [=?=] [$GetMethod$](|value|, %Symbol.iterator%).
+    1. <i id=from-iterable-conversion>From iterable</i>: Let |iteratorMethodRecord| be [=?=]
+       [$GetMethod$](|value|, {{%Symbol.iterator%}}).
 
-    1. If |iteratorMethodRecord|'s \[[Value]] is not undefined, then:
+       Note: This step is web-observable, and results in re-throwing any errors that the
+       {{%Symbol.iterator%}} method *getter* might have thrown.
 
-       Note: [$GetMethod$] might return a [=normal completion=] with an undefined value when the
-       object simply has no asyncIterator method.
+    1. If |iteratorMethodRecord|'s \[[Value]] is undefined or null, then jump to the step labeled <a
+       href=#from-promise-conversion>From Promise</a>.
+
+    1. If [$IsCallable$](|iteratorMethodRecord|'s \[[Value]]) is false, then [=exception/throw=] a
+       {{TypeError}}.
+
+       Otherwise:
 
        1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
           algorithm that takes a {{Subscriber}} |subscriber| and does the following:
@@ -563,7 +583,8 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
           1. If |iteratorRecord| is a [=throw completion=] then:
 
-             1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s \[[Value]].
+             1. Run |subscriber|'s {{Subscriber/error()}} method, given |iteratorRecord|'s
+                \[[Value]].
 
              1. Abort these steps.
 
@@ -579,13 +600,14 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
              1. If |nextRecord| is a [=throw completion=] then:
 
-                1. Run |subscriber|'s {{Subscriber/error()}} method, given |nextRecord|'s \[[Value]].
+                1. Run |subscriber|'s {{Subscriber/error()}} method, given |nextRecord|'s
+                   \[[Value]].
 
                 1. Abort these steps.
 
              1. Run |subscriber|'s {{Subscriber/next()}} given |nextRecord|'s \[[Value]].
 
-    1. If [$IsPromise$](|value|) is true, then:
+    1. <i id=from-promise-conversion>From Promise</i>: If [$IsPromise$](|value|) is true, then:
 
        1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an algorithm
           that takes a {{Subscriber}} |subscriber| and does the following:

--- a/spec.bs
+++ b/spec.bs
@@ -533,7 +533,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
                1. If [$Type$](|iteratorResult|) is not Object, then run |subscriber|'s
                   {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
 
-               1. Let |done| be [$IteratorComplete$](iteratorResult).
+               1. Let |done| be [$IteratorComplete$](|iteratorResult|).
 
                1. If |done| is a [=throw completion=], then run |subscriber|'s
                   {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
@@ -541,7 +541,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
                   Otherwise, if |done|'s \[[Value]] is true, then run |subscriber|'s
                   {{Subscriber/complete()}} and abort these steps.
 
-               1. Let |value| be [$IteratorValue$](|iteratorResult).
+               1. Let |value| be [$IteratorValue$](|iteratorResult|).
 
                1. If |value| is a [=throw completion=], then run |subscriber|'s
                   {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.


### PR DESCRIPTION
This makes a lot of progress towards #159 by specifying the semantics of `from()`, while also then using that algorithm in `takeUntil()`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/160.html" title="Last updated on Jan 25, 2025, 5:48 AM UTC (57b2d19)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/160/35be035...57b2d19.html" title="Last updated on Jan 25, 2025, 5:48 AM UTC (57b2d19)">Diff</a>