### PR TITLE
fix indentation in "subscribe to an" algo

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -529,10 +529,10 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        1. If |options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then [=close a
           subscription|close=] |subscriber|.
 
-    1. Otherwise, [=AbortSignal/add|add the following abort algorithm=] to |options|'s
-       {{SubscribeOptions/signal}}:
+       1. Otherwise, [=AbortSignal/add|add the following abort algorithm=] to |options|'s
+          {{SubscribeOptions/signal}}:
 
-       1. [=close a subscription|Close=] |subscriber|.
+          1. [=close a subscription|Close=] |subscriber|.
 
     1. If [=this=]'s [=Observable/subscribe callback=] is a {{SubscribeCallback}}, [=invoke=] it
        with |subscriber|.


### PR DESCRIPTION
These steps are numbered incorrectly due to wonky indentation. This fixes the steps so they're indented correctly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/162.html" title="Last updated on Jul 26, 2024, 1:05 PM UTC (cc5852c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/162/1b470a5...cc5852c.html" title="Last updated on Jul 26, 2024, 1:05 PM UTC (cc5852c)">Diff</a>