### PR TITLE
"subscribe to an": use |observer| instead of [=this=]

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -455,7 +455,7 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
   bindings on objects whose properties could be mutated by JavaScript. See
   [[#promise-returning-operators]] for usage of this.
 
-    1. If [=this=]'s [=relevant global object=] is a {{Window}} object, and its [=associated
+    1. If |observer|'s [=relevant global object=] is a {{Window}} object, and its [=associated
        Document=] is not [=Document/fully active=], then return.
 
     1. Let |internal observer| be a new [=internal observer=].
@@ -534,13 +534,13 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
        1. [=close a subscription|Close=] |subscriber|.
 
-    1. If [=this=]'s [=Observable/subscribe callback=] is a {{SubscribeCallback}}, [=invoke=] it
+    1. If |observer|'s [=Observable/subscribe callback=] is a {{SubscribeCallback}}, [=invoke=] it
        with |subscriber|.
 
        If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, call
        |subscriber|'s {{Subscriber/error()}} method with |E|.
 
-    1. Otherwise, run the steps given by [=this=]'s [=Observable/subscribe callback=], given
+    1. Otherwise, run the steps given by |observer|'s [=Observable/subscribe callback=], given
        |subscriber|.
 </div>
 


### PR DESCRIPTION
The "subscribe to an" algorithm references `[=this=]` which I believe is likely due to it being refactored from a method to an independant algorithm. It should use `|observable|`, referencing the given observable, which is otherwise not mentioned in the algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/163.html" title="Last updated on Jul 26, 2024, 1:10 PM UTC (6e1697a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/163/1b470a5...6e1697a.html" title="Last updated on Jul 26, 2024, 1:10 PM UTC (6e1697a)">Diff</a>