### PR TITLE
Fix indentation in first and last algos

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1301,7 +1301,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        : [=internal observer/next steps=]
        :: 1. [=Resolve=] |p| with the passed in <var ignore>value</var>.
 
-          1. [=AbortController/Signal abort=] |controller|.
+        1. [=AbortController/Signal abort=] |controller|.
 
        : [=internal observer/error steps=]
        :: [=Reject=] |p| with the passed in <var ignore>error</var>.
@@ -1351,7 +1351,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        : [=internal observer/next steps=]
        :: 1. Set |hasLastValue| to true.
 
-          1. Set |lastValue| to the passed in <var ignore>value</var>.
+        1. Set |lastValue| to the passed in <var ignore>value</var>.
 
        : [=internal observer/error steps=]
        :: [=Reject=] |p| with the passed in <var ignore>error</var>.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/164.html" title="Last updated on Jul 26, 2024, 7:08 PM UTC (775f93b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/164/1b470a5...775f93b.html" title="Last updated on Jul 26, 2024, 7:08 PM UTC (775f93b)">Diff</a>