### PR TITLE
Pass abortsignal reason to close a subscription

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -37,7 +37,7 @@ urlPrefix: https://dom.spec.whatwg.org; spec: DOM
     for: AbortSignal
       text: dependent signals; url: abortsignal-dependent-signals
       text: signal abort; url:abortsignal-signal-abort
-      text: reason; url:abortsignal-abort-reason
+      text: abort reason; url:abortsignal-abort-reason
 </pre>
 
 <style>
@@ -531,13 +531,13 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
        1. If |options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then [=close a
           subscription|close=] |subscriber| given |options|'s {{SubscribeOptions/signal}}
-          [=AbortSignal/reason=].
+          [=AbortSignal/abort reason=].
 
        1. Otherwise, [=AbortSignal/add|add the following abort algorithm=] to |options|'s
           {{SubscribeOptions/signal}}:
 
           1. [=close a subscription|Close=] |subscriber| with |options|'s
-             {{SubscribeOptions/signal}} [=AbortSignal/reason=].
+             {{SubscribeOptions/signal}} [=AbortSignal/abort reason=].
 
     1. If [=this=]'s [=Observable/subscribe callback=] is a {{SubscribeCallback}}, [=invoke=] it
        with |subscriber|.

--- a/spec.bs
+++ b/spec.bs
@@ -37,6 +37,7 @@ urlPrefix: https://dom.spec.whatwg.org; spec: DOM
     for: AbortSignal
       text: dependent signals; url: abortsignal-dependent-signals
       text: signal abort; url:abortsignal-signal-abort
+      text: reason; url:abortsignal-abort-reason
 </pre>
 
 <style>
@@ -262,7 +263,8 @@ The <dfn attribute for=Subscriber><code>signal</code></dfn> getter steps are to 
 </div>
 
 <div algorithm>
-  To <dfn>close a subscription</dfn> given a {{Subscriber}} |subscriber|, run these steps:
+  To <dfn>close a subscription</dfn> given a {{Subscriber}} |subscriber|, and
+  an optional {{any}} |reason|, run these steps:
 
     1. If |subscriber|'s [=Subscriber/active=] is false, then return.
 
@@ -292,9 +294,10 @@ observable.subscribe({}, {signal: outerController.signal});
 
     1. Set |subscriber|'s [=Subscriber/active=] boolean to false.
 
-    1. [=AbortSignal/Signal abort=] |subscriber|'s [=Subscriber/subscription controller=].
+    1. [=AbortSignal/Signal abort=] |subscriber|'s [=Subscriber/subscription controller=]
+       with |reason|, if it is given.
 
-       Issue: Abort with an appropriate abort reason.
+       Issue: Abort with an appropriate abort reason if none given.
 
     1. [=list/For each=] |teardown| of |subscriber|'s [=Subscriber/teardown callbacks=] sorted in
        reverse insertion order:
@@ -527,12 +530,14 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. If |options|'s {{SubscribeOptions/signal}} [=map/exists=], then:
 
        1. If |options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then [=close a
-          subscription|close=] |subscriber|.
+          subscription|close=] |subscriber| given |options|'s {{SubscribeOptions/signal}}
+          [=AbortSignal/reason=].
 
        1. Otherwise, [=AbortSignal/add|add the following abort algorithm=] to |options|'s
           {{SubscribeOptions/signal}}:
 
-          1. [=close a subscription|Close=] |subscriber|.
+          1. [=close a subscription|Close=] |subscriber| with |options|'s
+             {{SubscribeOptions/signal}} [=AbortSignal/reason=].
 
     1. If [=this=]'s [=Observable/subscribe callback=] is a {{SubscribeCallback}}, [=invoke=] it
        with |subscriber|.

--- a/spec.bs
+++ b/spec.bs
@@ -297,8 +297,6 @@ observable.subscribe({}, {signal: outerController.signal});
     1. [=AbortSignal/Signal abort=] |subscriber|'s [=Subscriber/subscription controller=]
        with |reason|, if it is given.
 
-       Issue: Abort with an appropriate abort reason if none given.
-
     1. [=list/For each=] |teardown| of |subscriber|'s [=Subscriber/teardown callbacks=] sorted in
        reverse insertion order:
 


### PR DESCRIPTION
Fixes #165. 

This seems to marry up with [Chrome's impl](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/subscriber.cc;l=64-72;drc=105770df485ace262780d95126bb60b1a16ec340;bpv=0;bpt=1):

```c++
    if (downstream_signal->aborted()) {
      CloseSubscription(
          script_state,
          /*abort_reason=*/downstream_signal->reason(script_state));
    } else {
      close_subscription_algorithm_handle_ = downstream_signal->AddAlgorithm(
          MakeGarbageCollected<CloseSubscriptionAlgorithm>(
              this, downstream_signal, script_state));
    }
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/166.html" title="Last updated on Aug 13, 2024, 5:08 PM UTC (7905c52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/166/530d498...7905c52.html" title="Last updated on Aug 13, 2024, 5:08 PM UTC (7905c52)">Diff</a>