### PR TITLE
Let the `value` argument be consistent

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -333,10 +333,10 @@ dictionary SubscribeOptions {
 
 callback Predicate = boolean (any value, unsigned long long index);
 callback Reducer = any (any accumulator, any currentValue);
-callback Mapper = any (any element, unsigned long long index);
+callback Mapper = any (any value, unsigned long long index);
 // Differs from Mapper only in return type, since this callback is exclusively
 // used to visit each element in a sequence, not transform it.
-callback Visitor = undefined (any element, unsigned long long index);
+callback Visitor = undefined (any value, unsigned long long index);
 
 [Exposed=*]
 interface Observable {


### PR DESCRIPTION
Am currently implementing `forEach` in WebKit, and noticed we had some [inconsistencies](https://github.com/WebKit/WebKit/blob/d128fcbc4cf949b84f671691d19297f0fda88349/Source/WebCore/dom/MapperCallback.idl#L26) with what we call the value we pass these callbacks. Lets tidy this up in the spec.

cc @keithamus


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/maraisr/observable/pull/167.html" title="Last updated on Aug 2, 2024, 3:41 AM UTC (ec10807)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/167/530d498...maraisr:ec10807.html" title="Last updated on Aug 2, 2024, 3:41 AM UTC (ec10807)">Diff</a>