### PR TITLE
Spec `inspect()` operator

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -329,16 +329,16 @@ dictionary SubscriptionObserver {
 callback ObservableInspectorAbortHandler = undefined (any value);
 
 dictionary ObservableInspector {
-  SubscriptionObserverCallback next;
-  SubscriptionObserverCallback error;
+  ObservableSubscriptionCallback next;
+  ObservableSubscriptionCallback error;
   VoidFunction complete;
 
   VoidFunction subscribe;
   ObservableInspectorAbortHandler abort;
 };
 
-typedef (SubscriptionObserverCallback or SubscriptionObserver) ObserverUnion;
-typedef (SubscriptionObserverCallback or ObservableInspector) ObservableInspectorUnion;
+typedef (ObservableSubscriptionCallback or SubscriptionObserver) ObserverUnion;
+typedef (ObservableSubscriptionCallback or ObservableInspector) ObservableInspectorUnion;
 
 dictionary SubscribeOptions {
   AbortSignal signal;
@@ -1103,9 +1103,9 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
     1. Let |subscribe callback| be a {{VoidFunction}}-or-null, initially null.
 
-    1. Let |next callback| be a {{SubscriptionObserverCallback}}-or-null, initially null.
+    1. Let |next callback| be a {{ObservableSubscriptionCallback}}-or-null, initially null.
 
-    1. Let |error callback| be a {{SubscriptionObserverCallback}}-or-null, initially null.
+    1. Let |error callback| be a {{ObservableSubscriptionCallback}}-or-null, initially null.
 
     1. Let |complete callback| be a {{VoidFunction}}-or-null, initially null.
 
@@ -1113,7 +1113,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
     1. Process |inspector_union| as follows:
          <dl class="switch">
-           <dt>If |inspector_union| is an {{SubscriptionObserverCallback}}</dt>
+           <dt>If |inspector_union| is an {{ObservableSubscriptionCallback}}</dt>
            <dd>
              1. Set |next callback| to |inspector_union|.
 
@@ -1153,7 +1153,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
           [=AbortController/signal=]:
 
           1. [=Invoke=] |abort callback| with |subscriber|'s [=Subscriber/subscription
-             controller=]'s [=AbortController/signal=]'s [=AbortSignal/reason=].
+             controller=]'s [=AbortController/signal=]'s [=AbortSignal/abort reason=].
 
              If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
              [=report the exception=] |E|.

--- a/spec.bs
+++ b/spec.bs
@@ -326,7 +326,19 @@ dictionary SubscriptionObserver {
   VoidFunction complete;
 };
 
-typedef (ObservableSubscriptionCallback or SubscriptionObserver) ObserverUnion;
+callback ObservableInspectorAbortHandler = undefined (any value);
+
+dictionary ObservableInspector {
+  SubscriptionObserverCallback next;
+  SubscriptionObserverCallback error;
+  VoidFunction complete;
+
+  VoidFunction subscribe;
+  ObservableInspectorAbortHandler abort;
+};
+
+typedef (SubscriptionObserverCallback or SubscriptionObserver) ObserverUnion;
+typedef (SubscriptionObserverCallback or ObservableInspector) ObservableInspectorUnion;
 
 dictionary SubscribeOptions {
   AbortSignal signal;
@@ -362,6 +374,7 @@ interface Observable {
   Observable drop(unsigned long long amount);
   Observable flatMap(Mapper mapper);
   Observable switchMap(Mapper mapper);
+  Observable inspect(optional ObservableInspectorUnion inspect_observer = {});
   Observable finally(VoidFunction callback);
 
   // Promise-returning operators.
@@ -1083,6 +1096,115 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
      1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |innerObservable| given
         |innerObserver| and |innerOptions|.
+</div>
+
+<div algorithm>
+  The <dfn for=Observable method><code>inspect(|inspector_union|)</code></dfn> method steps are:
+
+    1. Let |subscribe callback| be a {{VoidFunction}}-or-null, initially null.
+
+    1. Let |next callback| be a {{SubscriptionObserverCallback}}-or-null, initially null.
+
+    1. Let |error callback| be a {{SubscriptionObserverCallback}}-or-null, initially null.
+
+    1. Let |complete callback| be a {{VoidFunction}}-or-null, initially null.
+
+    1. Let |abort callback| be a {{ObservableInspectorAbortHandler}}-or-null, initially null.
+
+    1. Process |inspector_union| as follows:
+         <dl class="switch">
+           <dt>If |inspector_union| is an {{SubscriptionObserverCallback}}</dt>
+           <dd>
+             1. Set |next callback| to |inspector_union|.
+
+           <dt>If |inspector_union| is an {{ObservableInspector}}</dt>
+           <dd>
+             1. If {{ObservableInspector/subscribe}} [=map/exists=] in |inspector_union|, then set
+                |subscribe callback| to it.
+
+             1. If {{ObservableInspector/next}} [=map/exists=] in |inspector_union|, then set
+                |next callback| to it.
+
+             1. If {{ObservableInspector/error}} [=map/exists=] in |inspector_union|, then set
+                |error callback| to it.
+
+             1. If {{ObservableInspector/complete}} [=map/exists=] in |inspector_union|, then set
+                |complete callback| to it.
+
+             1. If {{ObservableInspector/abort}} [=map/exists=] in |inspector_union|, then set
+                |abort callback| to it.
+           </dd>
+         </dl>
+
+    1. Let |sourceObservable| be [=this=].
+
+    1. Let |observable| be a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
+       algorithm that takes a {{Subscriber}} |subscriber| and does the following:
+
+       1. If |subscribe callback| is not null, then [=invoke=] it.
+
+          If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then run
+          |subscriber|'s {{Subscriber/error()}} method, given |E|, and abort these steps.
+
+          Note: The result of this is that |sourceObservable| is never subscribed to.
+
+       1. If |abort callback| is not null, then [=AbortSignal/add|add the following abort
+          algorithm=] to |subscriber|'s [=Subscriber/subscription controller=]'s
+          [=AbortController/signal=]:
+
+          1. [=Invoke=] |abort callback| with |subscriber|'s [=Subscriber/subscription
+             controller=]'s [=AbortController/signal=]'s [=AbortSignal/reason=].
+
+             If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
+             [=report the exception=] |E|.
+
+       1. Let |sourceObserver| be a new [=internal observer=], initialized as follows:
+
+          : [=internal observer/next steps=]
+          :: 1. If |next callback| is not null, then [=invoke=] |next callback| with the passed in
+                |value|.
+
+                If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then:
+
+                  1. [=AbortSignal/Remove=] |abort callback| from |subscriber|'s
+                     [=Subscriber/subscription controller=]'s [=AbortController/signal=].
+
+                     Note: This step is important, because the |abort callback| is only meant to be
+                     called for *consumer-initiated* unsubscriptions. When the producer terminates
+                     the subscription (via |subscriber|'s {{Subscriber/error()}} or
+                     {{Subscriber/complete()}} methods) like below, we have to ensure that
+                     |abort callback| is not run.
+
+                     Issue: This matches Chromium's implementation, but consider holding a reference
+                     to the originally-passed-in {{SubscribeOptions}}'s {{SubscribeOptions/signal}}
+                     and just invoking |abort callback| when *it* aborts. The result is likely the
+                     same, but needs investigation.
+
+                  1. Run |subscriber|'s {{Subscriber/error()}} method, given |E|, and return.
+
+             1. Run |subscriber|'s {{Subscriber/next()}} method with the passed in |value|.
+
+          : [=internal observer/error steps=]
+          :: [=AbortSignal/Remove=] |abort callback| from |subscriber|'s [=Subscriber/subscription
+             controller=]'s [=AbortController/signal=], and run |subscriber|'s
+             {{Subscriber/error()}} method, given the passed in <var ignore>error</var>.
+
+          : [=internal observer/complete steps=]
+          :: [=AbortSignal/Remove=] |abort callback| from |subscriber|'s [=Subscriber/subscription
+             controller=]'s [=AbortController/signal=], and run |subscriber|'s
+             {{Subscriber/complete()}} method.
+
+       1. Let |options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is
+          |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=].
+
+       1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to |sourceObservable|
+          given |sourceObserver| and |options|.
+
+    1. Return |observable|.
+
+  <wpt>
+    /dom/observable/tentative/observable-inspect.any.js
+  </wpt>
 </div>
 
 <div algorithm>


### PR DESCRIPTION
Closes https://github.com/WICG/observable/issues/111.

See https://chromium-review.googlesource.com/c/chromium/src/+/5435614 for tests that have been upstreamed to the WPT repository.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/168.html" title="Last updated on Aug 22, 2024, 5:18 PM UTC (eae66ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/168/34820c9...eae66ae.html" title="Last updated on Aug 22, 2024, 5:18 PM UTC (eae66ae)">Diff</a>