### PR TITLE
Add standards issues links

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,18 @@ discussion comments:
 - https://github.com/whatwg/dom/issues/544#issuecomment-351607779
 - https://github.com/whatwg/dom/issues/544#issuecomment-351718686
 
+## Standards issues
+
+This section bares a collection of web standards and standards positions issues
+used to track the Observable proposal's life outside of this repository.
+
+ - https://github.com/mozilla/standards-positions/issues/945
+ - https://github.com/WebKit/standards-positions/issues/292
+ - https://chromestatus.com/feature/5154593776599040
+ - https://github.com/wintercg/proposal-common-minimum-api/issues/72
+ - https://github.com/w3ctag/design-reviews/issues/902
+ - https://github.com/nodejs/standards-positions/issues/1
+
 ## User needs
 
 Observables are designed to make event handling more ergonomic and composable.

--- a/README.md
+++ b/README.md
@@ -693,12 +693,14 @@ discussion comments:
 This section bares a collection of web standards and standards positions issues
 used to track the Observable proposal's life outside of this repository.
 
- - https://github.com/mozilla/standards-positions/issues/945
- - https://github.com/WebKit/standards-positions/issues/292
- - https://chromestatus.com/feature/5154593776599040
- - https://github.com/wintercg/proposal-common-minimum-api/issues/72
- - https://github.com/w3ctag/design-reviews/issues/902
- - https://github.com/nodejs/standards-positions/issues/1
+ - [Mozilla standards
+   position](https://github.com/mozilla/standards-positions/issues/945)
+ - [WebKit standards
+   position](https://github.com/WebKit/standards-positions/issues/292)
+ - [Chrome Status](https://chromestatus.com/feature/5154593776599040)
+ - [WinterCG](https://github.com/wintercg/proposal-common-minimum-api/issues/72)
+ - [Node.js](https://github.com/nodejs/standards-positions/issues/1)
+ - [W3C TAG review](https://github.com/w3ctag/design-reviews/issues/902)
 
 ## User needs
 


### PR DESCRIPTION
This can close https://github.com/WICG/observable/issues/93 which ultimately doesn't need to be open. It's just as easy (and less cluttered from an issues management perspective) to just have this content in the README.