### PR TITLE
Spec the `reduce()` operator

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1628,17 +1628,19 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
     1. Let |idx| be an {{unsigned long long}}, initially 0.
 
-    1. Let |accumulator| be |initialValue| if it is given, and the string "<code>unset</code>" otherwise.
+    1. Let |accumulator| be |initialValue| if it is given, and the string "<code>unset</code>"
+       otherwise.
 
     1. Let |observer| be a new [=internal observer=], initialized as follows:
 
        : [=internal observer/next steps=]
-       :: 1. If |accumulator| is the string "<code>unset</code>", then set |accumulator| to the
-             passed in |value| and abort these steps.
+       ::
+          1. If |accumulator| is the string "<code>unset</code>", then set |accumulator| to the
+             passed in |value|, set |idx| to |idx| + 1, and abort these steps.
 
              Note: This means that |reducer| will not be called with the first |value| that [=this=]
              produces set as the {{Reducer/currentValue}}. Rather, when the *second* value is
-             eventually emitted, we will call |reducer| with *it* as the {[Reducer/currentValue}},
+             eventually emitted, we will call |reducer| with *it* as the {{Reducer/currentValue}},
              and the first value (that we're saving here) as the {{Reducer/accumulator}}.
 
           1. [=Invoke=] |reducer| with |accumulator| as {{Reducer/accumulator}}, the passed in
@@ -1648,15 +1650,17 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
              If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
              [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
 
-         1. Set |idx| to |idx| + 1.
+          1. Set |idx| to |idx| + 1.
 
-         1. Set |accumulator| to |result|.
+          1. Set |accumulator| to |result|.
 
        : [=internal observer/error steps=]
        :: [=Reject=] |p| with the passed in <var ignore>error</var>.
 
        : [=internal observer/complete steps=]
-       :: [=Resolve=] |p| with false.
+       :: 1. If |accumulator| is not "<code>unset</code>", then [=resolve=] |p| with |accumulator|.
+
+          Otherwise, [=reject=] |p| with a {{TypeError}}.
 
     1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
        and |internal options|.

--- a/spec.bs
+++ b/spec.bs
@@ -345,7 +345,7 @@ dictionary SubscribeOptions {
 };
 
 callback Predicate = boolean (any value, unsigned long long index);
-callback Reducer = any (any accumulator, any currentValue);
+callback Reducer = any (any accumulator, any currentValue, unsigned long long index);
 callback Mapper = any (any value, unsigned long long index);
 // Differs from Mapper only in return type, since this callback is exclusively
 // used to visit each element in a sequence, not transform it.
@@ -1604,7 +1604,64 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
   The <dfn for=Observable method><code>reduce(|reducer|, |initialValue|, |options|)</code></dfn>
   method steps are:
 
-    1. <span class=XXX>TODO: Spec this and use |reducer|, |initialValue|, and |options|.</span>
+    1. Let |p| [=a new promise=].
+
+    1. Let |controller| be a [=new=] {{AbortController}}.
+
+    1. Let |internal options| be a new {{SubscribeOptions}} whose {{SubscribeOptions/signal}} is the
+       result of [=creating a dependent abort signal=] from the list
+       «|controller|'s [=AbortController/signal=], |options|'s
+       {{SubscribeOptions/signal}} if non-null», using {{AbortSignal}}, and the [=current realm=].
+
+    1. If |internal options|'s {{SubscribeOptions/signal}} is [=AbortSignal/aborted=], then:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s
+          [=AbortSignal/abort reason=].
+
+       1. Return |p|.
+
+    1. [=AbortSignal/add|Add the following abort algorithm=] to |internal options|'s
+       {{SubscribeOptions/signal}}:
+
+       1. [=Reject=] |p| with |internal options|'s {{SubscribeOptions/signal}}'s [=AbortSignal/abort
+          reason=].
+
+    1. Let |idx| be an {{unsigned long long}}, initially 0.
+
+    1. Let |accumulator| be |initialValue| if it is given, and the string "<code>unset</code>" otherwise.
+
+    1. Let |observer| be a new [=internal observer=], initialized as follows:
+
+       : [=internal observer/next steps=]
+       :: 1. If |accumulator| is the string "<code>unset</code>", then set |accumulator| to the
+             passed in |value| and abort these steps.
+
+             Note: This means that |reducer| will not be called with the first |value| that [=this=]
+             produces set as the {{Reducer/currentValue}}. Rather, when the *second* value is
+             eventually emitted, we will call |reducer| with *it* as the {[Reducer/currentValue}},
+             and the first value (that we're saving here) as the {{Reducer/accumulator}}.
+
+          1. [=Invoke=] |reducer| with |accumulator| as {{Reducer/accumulator}}, the passed in
+             |value| as {{Reducer/currentValue}}, and |idx| as {{Reducer/index}}. Let |result| be
+             the returned value.
+
+             If <a spec=webidl lt="an exception was thrown">an exception |E| was thrown</a>, then
+             [=reject=] |p| with |E|, and [=AbortController/signal abort=] |controller| with |E|.
+
+         1. Set |idx| to |idx| + 1.
+
+         1. Set |accumulator| to |result|.
+
+       : [=internal observer/error steps=]
+       :: [=Reject=] |p| with the passed in <var ignore>error</var>.
+
+       : [=internal observer/complete steps=]
+       :: [=Resolve=] |p| with false.
+
+    1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |observer|
+       and |internal options|.
+
+    1. Return |p|.
 </div>
 
 

--- a/spec.bs
+++ b/spec.bs
@@ -1628,15 +1628,14 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
 
     1. Let |idx| be an {{unsigned long long}}, initially 0.
 
-    1. Let |accumulator| be |initialValue| if it is given, and the string "<code>unset</code>"
-       otherwise.
+    1. Let |accumulator| be |initialValue| if it is given, and uninitialized otherwise.
 
     1. Let |observer| be a new [=internal observer=], initialized as follows:
 
        : [=internal observer/next steps=]
        ::
-          1. If |accumulator| is the string "<code>unset</code>", then set |accumulator| to the
-             passed in |value|, set |idx| to |idx| + 1, and abort these steps.
+          1. If |accumulator| is uninitialized (meaning no |initialValue| was passed in), then set
+             |accumulator| to the passed in |value|, set |idx| to |idx| + 1, and abort these steps.
 
              Note: This means that |reducer| will not be called with the first |value| that [=this=]
              produces set as the {{Reducer/currentValue}}. Rather, when the *second* value is


### PR DESCRIPTION
This specs the `reduce()` operator discussed in https://github.com/WICG/observable/issues/126. Tests will be upstreamed in https://chromium-review.googlesource.com/c/chromium/src/+/5817639. That should leave only `catch()` and `finally()` operators left.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/171.html" title="Last updated on Aug 28, 2024, 2:19 AM UTC (2760e00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/171/69ad0de...2760e00.html" title="Last updated on Aug 28, 2024, 2:19 AM UTC (2760e00)">Diff</a>