### PR TITLE
Correct a spelling mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ composable event handling.
 
 ### `EventTarget` integration
 
-This proposal adds aa `.when()` method to `EventTarget` that becomes a better
+This proposal adds a `.when()` method to `EventTarget` that becomes a better
 `addEventListener()`; specifically it returns a [new
 `Observable`](#the-observable-api) that adds a new event listener to the target
 when its `subscribe()` method is called. The Observable calls the subscriber's


### PR DESCRIPTION
"a" only needs one "a". :)