### PR TITLE
Update spec to mention rejecting with a new RangeError

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1523,7 +1523,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        :: [=Reject=] |p| with the passed in <var ignore>error</var>.
 
        : [=internal observer/complete steps=]
-       :: [=Reject=] |p| with a new {{RangeError}}, and message of "No values in Observable".
+       :: [=Reject=] |p| with a new {{RangeError}}.
 
           Note: This is only reached when the source {{Observable}} completes *before* it emits a
           single value.

--- a/spec.bs
+++ b/spec.bs
@@ -1523,13 +1523,10 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        :: [=Reject=] |p| with the passed in <var ignore>error</var>.
 
        : [=internal observer/complete steps=]
-       :: [=Resolve=] |p| with {{undefined}}.
+       :: [=Reject=] |p| with a new {{RangeError}}, and message of "No values in Observable".
 
           Note: This is only reached when the source {{Observable}} completes *before* it emits a
-          single value; in this case, resolving with {{undefined}} is harmless but makes it
-          difficult to distinguish between the first value trule being {{undefined}} and premature
-          completion. See <a href=https://github.com/WICG/observable/issues/132>#132</a> for
-          discussion on this.
+          single value.
 
     1. <a for=Observable lt="subscribe to an Observable">Subscribe</a> to [=this=] given |internal
        observer| and |internal options|.


### PR DESCRIPTION
Reading the [Chrome Implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=577-581?q=Observables%20foreach&ss=chromium) of `.first`, and the associated [wpt tests](https://github.com/web-platform-tests/wpt/blob/3585305e8365779fac42dd87e4f52c89c3e884a6/dom/observable/tentative/observable-first.any.js#L38-L54) I think it is valuable in having the spec reflective of this.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/maraisr/observable/pull/179.html" title="Last updated on Oct 20, 2024, 11:29 AM UTC (f77730e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/179/a56ef28...maraisr:f77730e.html" title="Last updated on Oct 20, 2024, 11:29 AM UTC (f77730e)">Diff</a>