### PR TITLE
Observable#last should also reject with RangeError with no last value

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1243,7 +1243,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
              ignore>value</var>.
 
           : [=internal observer/error steps=]
-          :: 
+          ::
              1. [=Invoke=] |callback| with the passed in <var ignore>error</var>. Let |result| be
                 the returned value.
 
@@ -1572,7 +1572,7 @@ For now, see [https://github.com/wicg/observable#operators](https://github.com/w
        : [=internal observer/complete steps=]
        :: 1. If |hasLastValue| is true, [=resolve=] |p| with |lastValue|.
 
-          1. Otherwise, [=resolve=] |p| with {{undefined}}.
+          1. Otherwise, [=reject=] |p| with a new {{RangeError}}.
 
              Note: See the note in {{Observable/first()}}.
 


### PR DESCRIPTION
With the last change in https://github.com/WICG/observable/pull/179, for observable first — we probably want the same to be true for last. There is an inflight wpt update diff for this too: https://github.com/web-platform-tests/wpt/pull/48717