### PR TITLE
Correct example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ const googTrades = streamStock('GOOG');
 const nflxTrades = streamStock('NFLX');
 
 const googController = new AbortController();
-const googSubscription = googTrades.subscribe({next: updateView}, {signal: googController.signal});
-const nflxSubscription = nflxTrades.subscribe({next: updateView, ...});
+googTrades.subscribe({next: updateView}, {signal: googController.signal});
+nflxTrades.subscribe({next: updateView, ...});
 
 // And the stream can disconnect later, which
 // automatically sends the unsubscription message


### PR DESCRIPTION
In the websocket example the return value of the subscribe calls are stored in variables.

The current spec doesn't implement a "subscription" return value, this might be a left over from the past.

Fixes #184 