### PR TITLE
We should forward the subscribers abort signal to eventListeners

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1811,11 +1811,11 @@ partial interface EventTarget {
                :: false
 
                : [=event listener/signal=]
-               :: null
+               :: |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=]
 
-                  Note: The {{AbortSignal}} for event listeners [=add an event listener|added=] by
-                  {{EventTarget/when()}} is managed by the {{Observable}} itself. See
-                  {{Observable/subscribe()}} and {{SubscribeOptions}}.
+                  Note: This ensures that the [=event listener=] is cleaned up when
+                  [=Subscriber/subscription controller=]'s [=AbortController/signal=] is [=AbortSignal/aborted=],
+                  regardless of an engine's ownership model.
 
     1. Return |observable|.
 </div>


### PR DESCRIPTION
I think there is a possible event listener leak that can occur if we don't have a mechanism to clean up event listeners as subscriptions are aborted.

In WebKit I confirmed, that if we were to follow the spec we'd keep listeners around for a little too long:

![CleanShot 2024-12-11 at 09 32 01](https://github.com/user-attachments/assets/1438347a-9043-40f2-8177-edc1b0ee8582)

Much [like Chrome's EventTarget implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/events/event_target.cc;l=362-366), WebKits' also immediately take ownership of the EventListener, so that despite the Observable is marked for GC (`active == 0`), the listener hangs around.

and I think Chrome had a similar discovery, as they [also forward the signal](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/events/event_target.cc;l=271;drc=616d60fca655937c2b730db94fd32d37ddff3bb5) to the event listener to trigger the abort steps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/maraisr/observable/pull/187.html" title="Last updated on Dec 12, 2024, 5:22 AM UTC (391600b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/187/a8bfae2...maraisr:391600b.html" title="Last updated on Dec 12, 2024, 5:22 AM UTC (391600b)">Diff</a>