### PR TITLE
`from()`: Close synchronous iterators properly

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -27,8 +27,9 @@ urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
   type: dfn
     text: current realm
     text: Object; url: sec-object-type
-    text: normal completion; url: sec-normalcompletion
-    text: throw completion; url: sec-throwcompletion
+    text: normal completion; url: sec-completion-record-specification-type
+    text: NormalCompletion; url: sec-normalcompletion
+    text: throw completion; url: sec-completion-record-specification-type
     url: sec-returnifabrupt-shorthands
       text: ?
       text: !
@@ -510,6 +511,14 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
          1. Let |iteratorRecord| be [=!=] |iteratorRecordCompletion|.
 
+         1. If |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=] is
+            [=AbortSignal/aborted=], then return.
+
+         1. [=AbortSignal/add|Add the following abort algorithm=] to |subscriber|'s
+            [=Subscriber/subscription controller=]'s [=AbortController/signal=]:
+
+            1. Run [$IteratorClose$](|iteratorRecord|, [=NormalCompletion=](UNUSED)).
+
          1. [=iteration/While=] true:
 
             1. Let |next| be [$IteratorStepValue$](|iteratorRecord|).
@@ -528,6 +537,9 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
                3. Return.
 
             1. Run |subscriber|'s {{Subscriber/next()}} given |next|.
+
+            1. If |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=]
+               is [=AbortSignal/aborted=], then [=iteration/break=].
 
     1. <i id=from-promise-conversion><b>From Promise</b></i>: If [$IsPromise$](|value|) is true,
        then:

--- a/spec.bs
+++ b/spec.bs
@@ -503,6 +503,9 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
        Otherwise, return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an
        algorithm that takes a {{Subscriber}} |subscriber| and does the following:
 
+         1. If |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=] is
+            [=AbortSignal/aborted=], then return.
+
          1. Let |iteratorRecordCompletion| be [$GetIterator$](|value|, sync).
 
          1. If |iteratorRecordCompletion| is a [=throw completion=], then run |subscriber|'s


### PR DESCRIPTION
This PR fixes `Observable.from()`'s synchronous iteration to respond to aborted signals properly, and close the iterator accordingly. Upon subscription, this PR adds checks to see whether the subscriber's signal is aborted:

1. The first is initially upon subscription. Consistent with [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=1946-1948;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42) and [tests](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/external/wpt/dom/observable/tentative/observable-from.any.js;l=1437-1464;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42) (tests are being modified [here](https://chromium-review.googlesource.com/c/chromium/src/+/6202182)).
2. The second is after the iterator is obtained, since this runs script and therefore could conceivably abort the subscription. This is consistent with the [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=2012-2017;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42) and [tests](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/external/wpt/dom/observable/tentative/observable-from.any.js;l=1466-1494;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42) (tests are being modified [here](https://chromium-review.googlesource.com/c/chromium/src/+/6202182)).
3. During the iteration, after a value has been pulled out and reported via `Subscriber#next()`, but before the next iteration starts. This is consistent with the [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=2007-2009;drc=27d34700b83f381c62e3a348de2e6dfdc08364b8) and [tests](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/external/wpt/dom/observable/tentative/observable-from.any.js;l=918-958;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42).

Furthermore, after the two checks, the subscription algorithm to run the IteratorRecord's "return" function is _also_ added to the signal. This is also consistent with the [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=1997;drc=27d34700b83f381c62e3a348de2e6dfdc08364b8) and tested by the above tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/192.html" title="Last updated on Jan 27, 2025, 6:55 PM UTC (f36ae85)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/192/2538ee1...f36ae85.html" title="Last updated on Jan 27, 2025, 6:55 PM UTC (f36ae85)">Diff</a>