### PR TITLE
`from()`: Support async iterable conversion

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -513,6 +513,12 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
 
          1. Let |nextCompletion| be [$IteratorNext$](|iteratorRecord|).
 
+            Note: We use [$IteratorNext$] here instead of [$IteratorStepValue$], because
+            [$IteratorStepValue$] expects the iterator's `next()` method to return an object that
+            can immediately be inspected for a value, whereas in the async iterator case, `next()`
+            is expected to return a Promise/thenable (which we wrap in a Promise and react to to get
+            that value).
+
          1. If |nextCompletion| is a [=throw completion=], then:
 
             1. [=Assert=]: |iteratorRecord|'s \[[Done]] is true.

--- a/spec.bs
+++ b/spec.bs
@@ -30,6 +30,7 @@ urlPrefix: https://tc39.es/ecma262/#; spec: ECMASCRIPT
     text: normal completion; url: sec-completion-record-specification-type
     text: NormalCompletion; url: sec-normalcompletion
     text: throw completion; url: sec-completion-record-specification-type
+    text: Iterator Record; url: sec-iterator-records
     url: sec-returnifabrupt-shorthands
       text: ?
       text: !
@@ -490,9 +491,100 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
     1. <i id=from-observable-conversion><b>From Observable</b></i>: If |value|'s [=specific type=]
        is an {{Observable}}, then return |value|.
 
-    1. Issue: Spec the <i><b>From async iterable</b></i> conversion steps which take place before
-       the iterable conversion steps. See <a
-       href=https://github.com/WICG/observable/issues/191>issue #191</a>.
+    1. <i id=from-async-iterable-conversion><b>From async iterable</b></i>: Let
+       |asyncIteratorMethod| be [=?=] [$GetMethod$](|value|, {{%Symbol.asyncIterator%}}).
+
+       Note: We use [$GetMethod$] instead of [$GetIterator$] because we're only probing for async
+       iterator protocol support, and we don't want to throw if it's not implemented.
+       [$GetIterator$] throws errors in BOTH of the following cases: (a) no iterator protocol is
+       implemented, (b) an iterator protocol is implemented, but isn't callable or its getter
+       throws. [$GetMethod$] lets us ONLY throw in the latter case.
+
+    1. If |asyncIteratorMethod|'s is undefined or null, then jump to the step labeled <a
+    href=#from-iterable-conversion>From iterable</a>.
+
+    1. Let |nextAlgorithm| be the following steps, given a {{Subscriber}} |subscriber| and an
+       [=Iterator Record=] |iteratorRecord|:
+
+         1. If |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=] is
+            [=AbortSignal/aborted=], then return.
+
+         1. Let |nextPromise| be a {{Promise}}-or-undefined, initially undefined.
+
+         1. Let |nextCompletion| be [$IteratorNext$](|iteratorRecord|).
+
+         1. If |nextCompletion| is a [=throw completion=], then:
+
+            1. [=Assert=]: |iteratorRecord|'s \[[Done]] is true.
+
+            1. Set |nextPromise| to [=a promise rejected with=] |nextRecord|'s \[[Value]].
+
+         1. Otherwise, if |nextRecord| is [=normal completion=], then set |nextPromise| to [=a
+            promise resolved with=] |nextRecord|'s \[[Value]].
+
+            Note: This is done in case |nextRecord|'s \[[Value]] is not *itself* already a
+            {{Promise}}.
+
+         1. [=React=] to |nextPromise|:
+
+             * If |nextPromise| was fulfilled with value |iteratorResult|, then:
+
+               1. If [$Type$](|iteratorResult|) is not Object, then run |subscriber|'s
+                  {{Subscriber/error()}} method with a {{TypeError}} and abort these steps.
+
+               1. Let |done| be [$IteratorComplete$](|iteratorResult|).
+
+               1. If |done| is a [=throw completion=], then run |subscriber|'s
+                  {{Subscriber/error()}} method with |done|'s \[[Value]] and abort these steps.
+
+               1. If |done|'s \[[Value]] is true, then run |subscriber|'s {{Subscriber/complete()}}
+                  and abort these steps.
+
+               1. Run |nextAlgorithm|.
+
+             * If |nextPromise| was rejected with reason |r|, then run |subscriber|'s
+               {{Subscriber/error()}} method given |r|.
+
+    1. Return a [=new=] {{Observable}} whose [=Observable/subscribe callback=] is an algorithm that
+       takes a {{Subscriber}} |subscriber| and does the following:
+
+       1. If |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=] is
+          [=AbortSignal/aborted=], then return.
+
+       1. Let |iteratorRecordCompletion| be [$GetIterator$](|value|, async).
+
+          Note: This both re-invokes any {{%Symbol.asyncIterator%}} method getters on |value|—note
+          that whether this is desirable is an extreme corner case, but it matches test
+          expectations; see <a href=https://github.com/WICG/observable/issues/127>issue#127</a> for
+          discussion—and invokes the protocol itself to obtain an [=Iterator Record=].
+
+       1. If |iteratorRecordCompletion| is a [=throw completion=], then run |subscriber|'s
+          {{Subscriber/error()}} method with |iteratorRecordCompletion|'s \[[Value]] and abort these
+          steps.
+
+          Note: This means we invoke the {{Subscriber/error()}} method synchronously with respect to
+          subscription, which is the only time this can happen for async iterables that are
+          converted to {{Observable}}s. In all other cases, errors are propagated to the observer
+          asynchronously, with microtask timing, by virtue of being wrapped in a rejected
+          {{Promise}} that |nextAlgorithm| [=reacts=] to. This synchronous-error-propagation
+          behavior is consistent with language constructs, i.e., **for-await of** loops that invoke
+          {{%Symbol.asyncIterator%}} and synchronously re-throw exceptions to catch blocks outside
+          the loop, before any [$Await|Awaiting$] takes place.
+
+       1. Let |iteratorRecord| be [=!=] |iteratorRecordCompletion|.
+
+       1. [=Assert=]: |iteratorRecord| is an [=Iterator Record=].
+
+       1. If |subscriber|'s [=Subscriber/subscription controller=]'s [=AbortController/signal=] is
+          [=AbortSignal/aborted=], then return.
+
+       1. [=AbortSignal/add|Add the following abort algorithm=] to |subscriber|'s
+          [=Subscriber/subscription controller=]'s [=AbortController/signal=]:
+
+          1. Run [$AsyncIteratorClose$](|iteratorRecord|, [=NormalCompletion=](|subscriber|'s
+             [=Subscriber/subscription controller=]'s [=AbortSignal/abort reason=])).
+
+       1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|.
 
     1. <i id=from-iterable-conversion><b>From iterable</b></i>: Let |iteratorMethod| be [=?=]
        [$GetMethod$](|value|, {{%Symbol.iterator%}}).


### PR DESCRIPTION
This PR closes https://github.com/WICG/observable/issues/191 by spec'ing async iterable support. Along with support for general iteration over async iterables, we support consulting the Subscriber's signal to discontinue the iteration at three points:

1. Immediately on subscription, so that we don't even pull out the iterator from the iterable. This matches the [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=1600-1602;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42) and [tests](https://chromium-review.googlesource.com/c/chromium/src/+/6202182).
2. After we obtain the iterator, the act of which may abort the signal. This also matches the [Chromium implementation](https://chromium-review.googlesource.com/c/chromium/src/+/6199630) and tests: [normal case](https://chromium-review.googlesource.com/c/chromium/src/+/6202182), [error case](https://chromium-review.googlesource.com/c/chromium/src/+/6199630).
3. Before we start each new iteration, to ensure we don't start after the signal has already been aborted. This matches the [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=1698-1704;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42) and [tests](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/web_tests/external/wpt/dom/observable/tentative/observable-from.any.js;l=959-1004;drc=4b00956a8d971cf5ec8ec45a105b5dd8802d4a42).

Additionally, an abort algorithm to call ECMAScript's [AsyncIteratorClose()](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-asynciteratorclose) abstract operation is added to the subscriber's signal before iteration begins. This ensures that the iterator's `return()` method is called with the abort signal's abort reason if it gets aborted before the iteration organically completes. This is also tested (see https://wpt.fyi/results/dom/observable/tentative/observable-from.any.html) in a number of situations.

As alluded to, we mostly delegate to various ECMAScript abstract operations that govern iteration, but once https://github.com/whatwg/webidl/pull/1397 lands should be able to use the abstractions offered in Web IDL directly, instead of manage most of it manually here. For now, this PR is somewhat redundant with the Web IDL one. It uses similar constructs to iterate over the async iterator.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/193.html" title="Last updated on Jan 27, 2025, 11:36 PM UTC (14d6fe6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/193/8a8c950...14d6fe6.html" title="Last updated on Jan 27, 2025, 11:36 PM UTC (14d6fe6)">Diff</a>