### PR TITLE
Call Subscriber's next method for async iterators

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -548,7 +548,14 @@ An <dfn>internal observer</dfn> is a [=struct=] with the following [=struct/item
                1. If |done|'s \[[Value]] is true, then run |subscriber|'s {{Subscriber/complete()}}
                   and abort these steps.
 
-               1. Run |nextAlgorithm|.
+               1. Let |value| be [$IteratorValue$](|iteratorResult|).
+
+               1. If |value| is a [=throw completion=], then run |subscriber|'s
+                  {{Subscriber/error()}} method with |value|'s \[[Value]] and abort these steps.
+
+               1. Run |subscriber|'s {{Subscriber/next()}} given |value|'s \[[Value]].
+
+               1. Run |nextAlgorithm| given |subscriber| and |iteratorRecord|.
 
              * If |nextPromise| was rejected with reason |r|, then run |subscriber|'s
                {{Subscriber/error()}} method given |r|.


### PR DESCRIPTION
Thanks to @jakearchibald for catching this and reporting it. This text must've existed in the spec PR at one point, since I've [quoted the spec text above the implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/observable.cc;l=1950-1954;drc=5f81609f7c343a17175b71d07ae02d6f5d09675f). I'm pretty sure what happened is when I did a ton of rebasing for the async stuff to finish it off in parallel with the ref-counted producer change, the later changes were lost, and here we are.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/observable/pull/202.html" title="Last updated on Feb 27, 2025, 5:24 PM UTC (bc22e18)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/observable/202/5e4a6a5...bc22e18.html" title="Last updated on Feb 27, 2025, 5:24 PM UTC (bc22e18)">Diff</a>